### PR TITLE
Fix surface view height

### DIFF
--- a/Examples/Maps/Maps/Base.lproj/Main.storyboard
+++ b/Examples/Maps/Maps/Base.lproj/Main.storyboard
@@ -60,9 +60,9 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ye3-uU-bq3">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="778"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="900"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ED1-gT-FBj">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="778"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="900"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <searchBar contentMode="redraw" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="Zcj-SE-gb8">
@@ -70,7 +70,7 @@
                                             <textInputTraits key="textInputTraits"/>
                                         </searchBar>
                                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="D7r-re-InH">
-                                            <rect key="frame" x="0.0" y="66" width="375" height="712"/>
+                                            <rect key="frame" x="0.0" y="66" width="375" height="834"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <view key="tableHeaderView" contentMode="scaleToFill" id="u28-LY-hIh" customClass="SearchHeaderView" customModule="Maps" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="116"/>
@@ -238,7 +238,7 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="Ye3-uU-bq3" firstAttribute="leading" secondItem="G74-X7-Za8" secondAttribute="leading" id="Kr2-sU-ZWZ"/>
-                            <constraint firstItem="Ye3-uU-bq3" firstAttribute="bottom" secondItem="G74-X7-Za8" secondAttribute="bottom" id="aWM-s3-3o4"/>
+                            <constraint firstItem="Ye3-uU-bq3" firstAttribute="bottom" secondItem="Ncl-E9-yRn" secondAttribute="bottom" constant="88" id="aWM-s3-3o4"/>
                             <constraint firstItem="Ye3-uU-bq3" firstAttribute="trailing" secondItem="G74-X7-Za8" secondAttribute="trailing" id="fEL-8y-Acc"/>
                             <constraint firstItem="Ye3-uU-bq3" firstAttribute="top" secondItem="Ncl-E9-yRn" secondAttribute="top" id="w77-ba-FrJ"/>
                         </constraints>
@@ -247,6 +247,7 @@
                     <connections>
                         <outlet property="searchBar" destination="Zcj-SE-gb8" id="BH7-Gy-RG5"/>
                         <outlet property="tableView" destination="D7r-re-InH" id="nRN-fY-b8j"/>
+                        <outlet property="visualEffectView" destination="Ye3-uU-bq3" id="rS6-Mq-OKs"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="EqR-Hp-zhc" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Examples/Maps/Maps/Base.lproj/Main.storyboard
+++ b/Examples/Maps/Maps/Base.lproj/Main.storyboard
@@ -70,7 +70,7 @@
                                             <textInputTraits key="textInputTraits"/>
                                         </searchBar>
                                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="D7r-re-InH">
-                                            <rect key="frame" x="0.0" y="66" width="375" height="834"/>
+                                            <rect key="frame" x="0.0" y="66" width="375" height="748"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <view key="tableHeaderView" contentMode="scaleToFill" id="u28-LY-hIh" customClass="SearchHeaderView" customModule="Maps" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="116"/>
@@ -227,7 +227,7 @@
                                         <constraint firstAttribute="trailing" secondItem="D7r-re-InH" secondAttribute="trailing" id="BES-GA-Btp"/>
                                         <constraint firstItem="D7r-re-InH" firstAttribute="leading" secondItem="ED1-gT-FBj" secondAttribute="leading" id="UTe-YL-17h"/>
                                         <constraint firstItem="Zcj-SE-gb8" firstAttribute="top" secondItem="ED1-gT-FBj" secondAttribute="top" constant="6" id="apU-Pd-PEO"/>
-                                        <constraint firstAttribute="bottom" secondItem="D7r-re-InH" secondAttribute="bottom" id="vfS-Lx-TXz"/>
+                                        <constraint firstAttribute="bottom" secondItem="D7r-re-InH" secondAttribute="bottom" constant="86" id="vfS-Lx-TXz"/>
                                         <constraint firstItem="D7r-re-InH" firstAttribute="top" secondItem="Zcj-SE-gb8" secondAttribute="bottom" constant="4" id="vro-cd-B9c"/>
                                         <constraint firstItem="Zcj-SE-gb8" firstAttribute="leading" secondItem="ED1-gT-FBj" secondAttribute="leading" id="wMb-L2-Z0W"/>
                                     </constraints>

--- a/Examples/Maps/Maps/ViewController.swift
+++ b/Examples/Maps/Maps/ViewController.swift
@@ -133,7 +133,8 @@ class SearchPanelViewController: UIViewController, UITableViewDataSource, UITabl
 
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var searchBar: UISearchBar!
-
+    @IBOutlet weak var visualEffectView: UIVisualEffectView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.dataSource = self
@@ -143,6 +144,15 @@ class SearchPanelViewController: UIViewController, UITableViewDataSource, UITabl
         textField.font = UIFont(name: textField.font!.fontName, size: 15.0)
 
         hideHeader()
+
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if #available(iOS 10, *) {
+            visualEffectView.layer.cornerRadius = 9.0
+            visualEffectView.clipsToBounds = true
+        }
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Examples/Samples/Sources/Base.lproj/Main.storyboard
+++ b/Examples/Samples/Sources/Base.lproj/Main.storyboard
@@ -70,12 +70,105 @@
                     <navigationItem key="navigationItem" title="Samples" id="wCF-su-7up"/>
                     <connections>
                         <outlet property="tableView" destination="7IS-PU-x0P" id="YFM-9W-eP4"/>
-                        <segue destination="bYI-y3-Rzb" kind="presentation" identifier="GoToTextView" id="6Ym-J6-Q6X"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eP2-DG-flv" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="57" y="27"/>
+        </scene>
+        <!--Item 2-->
+        <scene sceneID="lRc-OZ-sL4">
+            <objects>
+                <viewController id="RpE-lI-27a" customClass="TabBarContentViewController" customModule="Samples" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="JER-jz-KSq">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Item 2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AiP-dx-mFn">
+                                <rect key="frame" x="163.5" y="323" width="48" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IvG-yp-yzI">
+                                <rect key="frame" x="20" y="20" width="39" height="30"/>
+                                <state key="normal" title="Close"/>
+                                <connections>
+                                    <action selector="closeWithSender:" destination="RpE-lI-27a" eventType="touchUpInside" id="hj3-Xv-6Gq"/>
+                                    <action selector="closeWithSender:" destination="bYI-y3-Rzb" eventType="touchUpInside" id="rg4-OH-Ojn"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="IvG-yp-yzI" firstAttribute="top" secondItem="2Cd-km-qEk" secondAttribute="top" id="18k-sV-PgT"/>
+                            <constraint firstItem="AiP-dx-mFn" firstAttribute="centerY" secondItem="JER-jz-KSq" secondAttribute="centerY" id="NUc-tM-0dN"/>
+                            <constraint firstItem="AiP-dx-mFn" firstAttribute="centerX" secondItem="JER-jz-KSq" secondAttribute="centerX" id="hwP-mu-Vmz"/>
+                            <constraint firstItem="IvG-yp-yzI" firstAttribute="leading" secondItem="2Cd-km-qEk" secondAttribute="leading" constant="20" id="pYt-jE-CTF"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="2Cd-km-qEk"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" tag="1" title="Item 2" id="qb3-RB-B28"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="NhZ-u5-Beh" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="326" y="1575"/>
+        </scene>
+        <!--Item 1-->
+        <scene sceneID="m6X-j6-yBM">
+            <objects>
+                <viewController id="lto-Zc-Vtp" customClass="TabBarContentViewController" customModule="Samples" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ji9-Ez-N7i">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Item 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uoW-c8-9wx">
+                                <rect key="frame" x="164.5" y="323" width="46" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eFN-tN-4Ct">
+                                <rect key="frame" x="20" y="20" width="39" height="30"/>
+                                <state key="normal" title="Close"/>
+                                <connections>
+                                    <action selector="closeWithSender:" destination="bYI-y3-Rzb" eventType="touchUpInside" id="YL4-GP-ZEZ"/>
+                                    <action selector="closeWithSender:" destination="lto-Zc-Vtp" eventType="touchUpInside" id="llo-9x-fQv"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="eFN-tN-4Ct" firstAttribute="leading" secondItem="f88-U8-Vja" secondAttribute="leading" constant="20" id="5BT-yZ-EKe"/>
+                            <constraint firstItem="uoW-c8-9wx" firstAttribute="centerY" secondItem="ji9-Ez-N7i" secondAttribute="centerY" id="Nyw-Wt-78z"/>
+                            <constraint firstItem="eFN-tN-4Ct" firstAttribute="top" secondItem="f88-U8-Vja" secondAttribute="top" id="hUV-3a-XkY"/>
+                            <constraint firstItem="uoW-c8-9wx" firstAttribute="centerX" secondItem="ji9-Ez-N7i" secondAttribute="centerX" id="wDv-OH-7PX"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="f88-U8-Vja"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Item 1" id="HEV-kf-jxH"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bkL-bc-hZC" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-380" y="1576"/>
+        </scene>
+        <!--Tab Bar View Controller-->
+        <scene sceneID="nQ5-PV-qFw">
+            <objects>
+                <tabBarController storyboardIdentifier="TabBarViewController" id="c7K-XJ-TlT" customClass="TabBarViewController" customModule="Samples" customModuleProvider="target" sceneMemberID="viewController">
+                    <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="BPL-Dp-5pJ">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="49"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="lto-Zc-Vtp" kind="relationship" relationship="viewControllers" id="6hP-AH-YiH"/>
+                        <segue destination="RpE-lI-27a" kind="relationship" relationship="viewControllers" id="g6X-Sq-uSW"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Z9x-EI-p2b" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-183" y="806"/>
         </scene>
         <!--Modal View Controller-->
         <scene sceneID="C9P-Ns-Qrq">
@@ -114,7 +207,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fbi-LZ-M4Y" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="57" y="-758"/>
+            <point key="canvasLocation" x="561" y="806"/>
         </scene>
         <!--Detail View Controller-->
         <scene sceneID="b6k-zi-3wn">
@@ -169,7 +262,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Wqk-xl-O3I" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="836" y="492.95352323838085"/>
+            <point key="canvasLocation" x="1442" y="-23"/>
         </scene>
         <!--Debug Text View Controller-->
         <scene sceneID="Bkq-O7-q4A">
@@ -241,7 +334,7 @@ Section 1.10.33 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x1h-y1-h8q" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="836" y="-446"/>
+            <point key="canvasLocation" x="729" y="-23"/>
         </scene>
     </scenes>
 </document>

--- a/Examples/Samples/Sources/Base.lproj/Main.storyboard
+++ b/Examples/Samples/Sources/Base.lproj/Main.storyboard
@@ -134,11 +134,31 @@
                                     <action selector="closeWithSender:" destination="YC8-ae-15L" eventType="touchUpInside" id="Z2v-19-S5k"/>
                                 </connections>
                             </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8yw-OC-Ubk">
+                                <rect key="frame" x="0.0" y="690" width="375" height="88"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="88" id="jwV-YU-tXG"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kva-Z7-0qY" customClass="OnSafeAreaView" customModule="Samples" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="734" width="375" height="44"/>
+                                <color key="backgroundColor" red="0.0078431372550000003" green="0.72156862749999995" blue="0.45882352939999999" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="DQJ-cY-cKx"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="noi-1a-5bZ" firstAttribute="top" secondItem="g7l-kO-y7q" secondAttribute="top" constant="12" id="EQy-cr-F2Y"/>
+                            <constraint firstItem="8yw-OC-Ubk" firstAttribute="bottom" secondItem="g7l-kO-y7q" secondAttribute="bottom" id="JOL-wC-w74"/>
+                            <constraint firstItem="8yw-OC-Ubk" firstAttribute="leading" secondItem="tAi-nk-rDB" secondAttribute="leading" id="RiJ-Hb-OOZ"/>
+                            <constraint firstItem="8yw-OC-Ubk" firstAttribute="trailing" secondItem="tAi-nk-rDB" secondAttribute="trailing" id="Sof-yL-mwK"/>
+                            <constraint firstItem="Kva-Z7-0qY" firstAttribute="trailing" secondItem="tAi-nk-rDB" secondAttribute="trailing" id="kkp-Yo-FQW"/>
                             <constraint firstItem="tAi-nk-rDB" firstAttribute="trailing" secondItem="noi-1a-5bZ" secondAttribute="trailing" constant="12" id="lv9-Nf-HNB"/>
+                            <constraint firstItem="Kva-Z7-0qY" firstAttribute="leading" secondItem="tAi-nk-rDB" secondAttribute="leading" id="oVC-i1-TwS"/>
+                            <constraint firstItem="tAi-nk-rDB" firstAttribute="bottom" secondItem="Kva-Z7-0qY" secondAttribute="bottom" id="rW2-mF-5DR"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="tAi-nk-rDB"/>
                     </view>
@@ -149,7 +169,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Wqk-xl-O3I" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="836" y="493.5960591133005"/>
+            <point key="canvasLocation" x="836" y="492.95352323838085"/>
         </scene>
         <!--Debug Text View Controller-->
         <scene sceneID="Bkq-O7-q4A">

--- a/Examples/Samples/Sources/UIComponents.swift
+++ b/Examples/Samples/Sources/UIComponents.swift
@@ -86,3 +86,18 @@ class SafeAreaView: UIView {
             ])
     }
 }
+
+
+@IBDesignable
+class OnSafeAreaView: UIView {
+    override func prepareForInterfaceBuilder() {
+        let label = UILabel()
+        label.text = "On Safe Area"
+        addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: -4.0),
+            ])
+    }
+}

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -365,11 +365,14 @@ class TwoTabBarPanel2Layout: FloatingPanelLayout {
     var supportedPositions: [FloatingPanelPosition] {
         return [.full, .half]
     }
+    var bottomInteractionBuffer: CGFloat {
+        return 261.0 - 22.0
+    }
 
     func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
         case .full: return 16.0
-        case .half: return 261
+        case .half: return 261.0
         default: return nil
         }
     }

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -189,7 +189,7 @@ class DebugTableViewController: UITableViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        print("Content View: viewDidAppear")
+        print("Content View: viewDidAppear", view.bounds)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Examples/Stocks/Stocks/ViewController.swift
+++ b/Examples/Stocks/Stocks/ViewController.swift
@@ -106,11 +106,14 @@ class FloatingPanelStocksLayout: FloatingPanelLayout {
         return [.full, .half, .tip]
     }
 
-    public var initialPosition: FloatingPanelPosition {
+    var initialPosition: FloatingPanelPosition {
         return .tip
     }
 
-    public func insetFor(position: FloatingPanelPosition) -> CGFloat? {
+    var topInteractionBuffer: CGFloat { return 0.0 }
+    var bottomInteractionBuffer: CGFloat { return 0.0 }
+
+    func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
         case .full: return 56.0
         case .half: return 262.0
@@ -118,7 +121,7 @@ class FloatingPanelStocksLayout: FloatingPanelLayout {
         }
     }
 
-    public func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
+    func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
         return [
             surfaceView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 0.0),
             surfaceView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor, constant: 0.0),

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -370,7 +370,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
         switch supportedPositions {
         case Set([.full, .half]):
-            return targetPosition(from: [.half, .tip], at: currentY, velocity: velocity)
+            return targetPosition(from: [.full, .half], at: currentY, velocity: velocity)
         case Set([.half, .tip]):
             return targetPosition(from: [.half, .tip], at: currentY, velocity: velocity)
         case Set([.full, .tip]):

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -288,9 +288,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         let y = rect.offsetBy(dx: 0.0, dy: dy).origin.y
 
         let topY = layoutAdapter.topY
-        let topInset = layoutAdapter.topInset
         let topBuffer = layoutAdapter.layout.topInteractionBuffer
-
         let bottomY = layoutAdapter.bottomY
         let bottomBuffer = layoutAdapter.layout.bottomInteractionBuffer
 
@@ -300,7 +298,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 return max(topY, min(bottomY, y))
             }
         }
-        return max(topY - topInset + topBuffer, min(bottomY + bottomBuffer, y))
+        return max(topY - topBuffer, min(bottomY + bottomBuffer, y))
     }
 
     private func startAnimation(to targetPosition: FloatingPanelPosition, at distance: CGFloat, with velocity: CGPoint) {

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -133,7 +133,6 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
         if let parent = parent {
             self.update(safeAreaInsets: parent.layoutInsets)
         }
-        floatingPanel.layoutAdapter.updateHeight()
         floatingPanel.backdropView.isHidden = (traitCollection.verticalSizeClass == .compact)
     }
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -8,22 +8,25 @@ import UIKit
 public protocol FloatingPanelLayout: class {
     /// Returns the initial position of a floating panel
     var initialPosition: FloatingPanelPosition { get }
+
     /// Returns an array of FloatingPanelPosition object to tell the applicable position the floating panel controller
     var supportedPositions: [FloatingPanelPosition] { get }
 
     /// Return the interaction buffer of full position. Default is 6.0.
     var topInteractionBuffer: CGFloat { get }
+
     /// Return the interaction buffer of full position. Default is 6.0.
     var bottomInteractionBuffer: CGFloat { get }
 
-    /// Returns a CGFloat value for a floating panel position(full, half, tip).
-    /// A value for full position indicates an inset from the safe area top.
-    /// On the other hand, values fro half and tip positions indicate insets from the safe area bottom.
+    /// Returns a CGFloat value to determine a floating panel height for each positions(full, half and tip).
+    /// A value for full position indicates a top inset from a safe area.
+    /// On the other hand, values for half and tip positions indicate bottom insets from a safe area.
     /// If a position doesn't contain the supported positions, return nil.
     func insetFor(position: FloatingPanelPosition) -> CGFloat?
-    /// Returns layout constraints for a surface view of a floaitng panel.
-    /// The layout constraints must not include ones for topAnchor and bottomAnchor
-    /// because constarints for them will be added by the floating panel controller.
+
+    /// Returns X-axis and width layout constraints of the surface view of a floaitng panel.
+    /// You must not include any Y-axis and height layout constraints of the surface view
+    /// because their constarints will be configured by the floating panel controller.
     func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint]
 
     /// Return the backdrop alpha of black color in full position. Default is 0.3.

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -92,7 +92,11 @@ class FloatingPanelLayoutAdapter {
 
     var layout: FloatingPanelLayout
 
-    var safeAreaInsets: UIEdgeInsets = .zero
+    var safeAreaInsets: UIEdgeInsets = .zero {
+        didSet {
+            updateHeight()
+        }
+    }
 
     private var heightBuffer: CGFloat = 88.0 // For bounce
     private var fixedConstraints: [NSLayoutConstraint] = []

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -127,7 +127,7 @@ class FloatingPanelLayoutAdapter {
     var adjustedContentInsets: UIEdgeInsets {
         return UIEdgeInsets(top: 0.0,
                             left: 0.0,
-                            bottom: (safeAreaInsets.top + topInset) + (heightBuffer + safeAreaInsets.bottom),
+                            bottom: safeAreaInsets.bottom,
                             right: 0.0)
     }
 
@@ -202,12 +202,16 @@ class FloatingPanelLayoutAdapter {
             }
         }
 
-        if let heightConstraints = self.heightConstraints {
-            NSLayoutConstraint.deactivate([heightConstraints])
+        if let consts = self.heightConstraints {
+            NSLayoutConstraint.deactivate([consts])
         }
-        let heightConstraints = surfaceView.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.height + heightBuffer)
-        NSLayoutConstraint.activate([heightConstraints])
-        self.heightConstraints = heightConstraints
+
+        let height = UIScreen.main.bounds.height - (safeAreaInsets.top + topInset)
+        let consts = surfaceView.heightAnchor.constraint(equalToConstant: height)
+
+        NSLayoutConstraint.activate([consts])
+        heightConstraints = consts
+        surfaceView.bottomOverflow = heightBuffer
     }
 
     func activateLayout(of state: FloatingPanelPosition?) {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -12,10 +12,10 @@ public protocol FloatingPanelLayout: class {
     /// Returns an array of FloatingPanelPosition object to tell the applicable position the floating panel controller
     var supportedPositions: [FloatingPanelPosition] { get }
 
-    /// Return the interaction buffer of full position. Default is 6.0.
+    /// Return the interaction buffer to the top from the top position. Default is 6.0.
     var topInteractionBuffer: CGFloat { get }
 
-    /// Return the interaction buffer of full position. Default is 6.0.
+    /// Return the interaction buffer to the bottom from the bottom position. Default is 6.0.
     var bottomInteractionBuffer: CGFloat { get }
 
     /// Returns a CGFloat value to determine a floating panel height for each positions(full, half and tip).
@@ -109,18 +109,22 @@ class FloatingPanelLayoutAdapter {
     private var offConstraints: [NSLayoutConstraint] = []
     private var heightConstraints: NSLayoutConstraint? = nil
 
-    var topInset: CGFloat {
+    private var fullInset: CGFloat {
         return layout.insetFor(position: .full) ?? 0.0
     }
-    var halfInset: CGFloat {
+    private var halfInset: CGFloat {
         return layout.insetFor(position: .half) ?? 0.0
     }
-    var tipInset: CGFloat {
+    private var tipInset: CGFloat {
         return layout.insetFor(position: .tip) ?? 0.0
     }
 
     var topY: CGFloat {
-        return (safeAreaInsets.top + topInset)
+        if layout.supportedPositions.contains(.full) {
+            return (safeAreaInsets.top + fullInset)
+        } else {
+            return middleY
+        }
     }
 
     var middleY: CGFloat {
@@ -128,7 +132,11 @@ class FloatingPanelLayoutAdapter {
     }
 
     var bottomY: CGFloat {
-        return surfaceView.superview!.bounds.height - (safeAreaInsets.bottom + tipInset)
+        if layout.supportedPositions.contains(.tip) {
+            return surfaceView.superview!.bounds.height - (safeAreaInsets.bottom + tipInset)
+        } else {
+            return middleY
+        }
     }
 
     var adjustedContentInsets: UIEdgeInsets {
@@ -185,7 +193,7 @@ class FloatingPanelLayoutAdapter {
         // Flexible surface constarints for full, half, tip and off
         fullConstraints = [
             surfaceView.topAnchor.constraint(equalTo: parent.layoutGuide.topAnchor,
-                                             constant: topInset),
+                                             constant: fullInset),
         ]
         halfConstraints = [
             surfaceView.topAnchor.constraint(equalTo: parent.layoutGuide.bottomAnchor,
@@ -213,7 +221,7 @@ class FloatingPanelLayoutAdapter {
             NSLayoutConstraint.deactivate([consts])
         }
 
-        let height = UIScreen.main.bounds.height - (safeAreaInsets.top + topInset)
+        let height = UIScreen.main.bounds.height - (safeAreaInsets.top + fullInset)
         let consts = surfaceView.heightAnchor.constraint(equalToConstant: height)
 
         NSLayoutConstraint.activate([consts])

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -102,6 +102,10 @@ public class FloatingPanelSurfaceView: UIView {
             grabberHandle.heightAnchor.constraint(equalToConstant: grabberHandle.frame.height),
             grabberHandle.centerXAnchor.constraint(equalTo: centerXAnchor),
             ])
+
+        let shadowLayer = CAShapeLayer()
+        layer.insertSublayer(shadowLayer, at: 0)
+        self.shadowLayer = shadowLayer
     }
 
     public override func layoutSubviews() {
@@ -131,18 +135,9 @@ public class FloatingPanelSurfaceView: UIView {
     }
 
     private func updateShadowLayer() {
-        if shadowLayer != nil {
-            shadowLayer.removeFromSuperlayer()
-        }
-        shadowLayer = makeShadowLayer()
-        layer.insertSublayer(shadowLayer, at: 0)
-    }
-
-    private func makeShadowLayer() -> CAShapeLayer {
         log.debug("SurfaceView bounds", bounds)
-        let shadowLayer = CAShapeLayer()
         var rect = bounds
-        rect.size.height += bottomOverflow
+        rect.size.height += bottomOverflow // Expand the height for overflow buffer
         let path = UIBezierPath(roundedRect: rect,
                                 byRoundingCorners: [.topLeft, .topRight],
                                 cornerRadii: CGSize(width: cornerRadius, height: cornerRadius))
@@ -155,6 +150,5 @@ public class FloatingPanelSurfaceView: UIView {
             shadowLayer.shadowOpacity = shadowOpacity
             shadowLayer.shadowRadius = shadowRadius
         }
-        return shadowLayer
     }
 }

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -22,6 +22,7 @@ public class FloatingPanelSurfaceView: UIView {
     public var contentView: UIView!
 
     private var color: UIColor? = .white { didSet { setNeedsDisplay() } }
+    var bottomOverflow: CGFloat = 0.0 { didSet { setNeedsDisplay() }}
 
     public override var backgroundColor: UIColor? {
         get { return color }
@@ -73,6 +74,7 @@ public class FloatingPanelSurfaceView: UIView {
 
     private func render() {
         super.backgroundColor = .clear
+        self.clipsToBounds = false
 
         let contentView = FloatingPanelSurfaceContentView()
         addSubview(contentView)
@@ -120,7 +122,9 @@ public class FloatingPanelSurfaceView: UIView {
     private func makeShadowLayer() -> CAShapeLayer {
         log.debug("SurfaceView bounds", bounds)
         let shadowLayer = CAShapeLayer()
-        let path = UIBezierPath(roundedRect: bounds,
+        var rect = bounds
+        rect.size.height += bottomOverflow
+        let path = UIBezierPath(roundedRect: rect,
                                 byRoundingCorners: [.topLeft, .topRight],
                                 cornerRadii: CGSize(width: cornerRadius, height: cornerRadius))
         shadowLayer.path = path.cgPath

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ class FloatingPanelStocksBehavior: FloatingPanelBehavior {
         return 15.0
     }
 
-    func interactionAnimator(to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
+    func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
         let damping = self.damping(with: velocity)
         let springTiming = UISpringTimingParameters(dampingRatio: damping, initialVelocity: velocity)
         return UIViewPropertyAnimator(duration: 0.5, timingParameters: springTiming)

--- a/README.md
+++ b/README.md
@@ -216,6 +216,23 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 }
 ```
 
+## Notes
+
+###  FloatingPanelSurfaceContentView
+
+* On iOS 10,   `FloatingPanelSurfaceContentView.cornerRadius` isn't not automatically masked with the top rounded corners  because of UIVisualEffectView issue. See https://forums.developer.apple.com/thread/50854. 
+So you need to draw top rounding corners of your content.  Here is an example in Examples/Maps.
+```
+override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    if #available(iOS 10, *) {
+        visualEffectView.layer.cornerRadius = 9.0
+        visualEffectView.clipsToBounds = true
+    }
+}
+```
+* If you sets clear color to `FloatingPanelSurfaceContentView.backgrounColor`, please note the bottom overflow of your content on bouncing at full position. To prevent it, you need to expand your content. For example, See Example/Maps's Auto Layout settings of UIVisualEffectView in Main.storyborad.
+
 ## Author
 
 Shin Yamamoto <shin@scenee.com>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
+[![Version](https://img.shields.io/cocoapods/v/FloatingPanel.svg)](https://cocoapods.org/pods/FloatingPanel)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Platform](https://img.shields.io/cocoapods/p/FloatingPanel.svg)](https://cocoapods.org/pods/FloatingPanel)
+[![Swift 4.2](https://img.shields.io/badge/Swift-4.2-orange.svg?style=flat)](https://swift.org/)
+
 #  FloatingPanel
+
 
 FloatingPanel is a simple and easy-to-use UI component for a new interface introduced in Apple Maps, Shortcuts and Stocks app.
 The new interface displays the related contents and utilities in parallel as a user wants.
@@ -7,6 +13,30 @@ The new interface displays the related contents and utilities in parallel as a u
 ![Stocks](https://github.com/SCENEE/FloatingPanel/blob/master/assets/stocks.gif)
 
 ![Maps(Landscape)](https://github.com/SCENEE/FloatingPanel/blob/master/assets/maps-landscape.gif)
+
+<!-- TOC -->
+
+- [Features](#features)
+- [Requirements](#requirements)
+- [Installation](#installation)
+  - [CocoaPods](#cocoapods)
+  - [Carthage](#carthage)
+- [Getting Started](#getting-started)
+- [Usage](#usage)
+  - [Customize the layout of a floating panel with  `FloatingPanelLayout` protocol](#customize-the-layout-of-a-floating-panel-with--floatingpanellayout-protocol)
+    - [Change the initial position, supported positions and height](#change-the-initial-position-supported-positions-and-height)
+    - [Support your landscape layout](#support-your-landscape-layout)
+  - [Customize the behavior with `FloatingPanelBehavior` protocol](#customize-the-behavior-with-floatingpanelbehavior-protocol)
+    - [Modify your floating panel's interaction](#modify-your-floating-panels-interaction)
+  - [Create an additional floating panel for a detail](#create-an-additional-floating-panel-for-a-detail)
+  - [Move a positon with an animation](#move-a-positon-with-an-animation)
+  - [Make your contents correspond with a floating panel behavior](#make-your-contents-correspond-with-a-floating-panel-behavior)
+- [Notes](#notes)
+  - [FloatingPanelSurfaceView's issue on iOS 10](#floatingpanelsurfaceviews-issue-on-ios-10)
+- [Author](#author)
+- [License](#license)
+
+<!-- /TOC -->
 
 ## Features
 
@@ -87,44 +117,39 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 
 ## Usage
 
-### Move a positon with an animation
+### Customize the layout of a floating panel with  `FloatingPanelLayout` protocol
 
-Move a floating panel to the top and middle of a view while opening and closeing a search bar like Apple Maps.
-
-```swift
-    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        ...
-        fpc.move(to: .half, animated: true)
-    }
-
-    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
-        ...
-        fpc.move(to: .full, animated: true)
-    }
-```
-
-### Make your contents correspond with FloatingPanel behavior
+#### Change the initial position, supported positions and height
 
 ```swift
 class ViewController: UIViewController, FloatingPanelControllerDelegate {
     ...
-    func floatingPanelWillBeginDragging(_ vc: FloatingPanelController) {
-        if vc.position == .full {
-            searchVC.searchBar.showsCancelButton = false
-            searchVC.searchBar.resignFirstResponder()
-        }
-    }
-
-    func floatingPanelDidEndDragging(_ vc: FloatingPanelController, withVelocity velocity: CGPoint, targetPosition: FloatingPanelPosition) {
-        if targetPosition != .full {
-            searchVC.hideHeader()
-        }
+    func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
+        return MyFloatingPanelLayout()
     }
     ...
 }
+
+class MyFloatingPanelLayout: FloatingPanelLayout {
+    public var initialPosition: FloatingPanelPosition {
+        return .tip
+    }
+    public var supportedPositions: [FloatingPanelPosition] {
+        return [.full, .half, .tip]
+    }
+
+    public func insetFor(position: FloatingPanelPosition) -> CGFloat? {
+        switch position {
+            case .full: return 16.0 # A top inset from safe area
+            case .half: return 216.0 # A bottom inset from the safe area
+            case .tip: return 44.0 # A bottom inset from the safe area
+            default: return nil
+        }
+    }
+}
 ```
 
-### Support your landscape layout with a `FloatingPanelLayout` object
+#### Support your landscape layout
 
 ```swift
 class ViewController: UIViewController, FloatingPanelControllerDelegate {
@@ -160,7 +185,9 @@ class FloatingPanelLandscapeLayout: FloatingPanelLayout {
 }
 ```
 
-### Modify your floating panel's interaction with a `FloatingPanelBehavior` object
+### Customize the behavior with `FloatingPanelBehavior` protocol
+
+#### Modify your floating panel's interaction
 
 ```swift
 class ViewController: UIViewController, FloatingPanelControllerDelegate {
@@ -216,13 +243,50 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 }
 ```
 
+### Move a positon with an animation
+
+In the following example, I move a floating panel to full or half position while opening or closeing a search bar like Apple Maps.
+
+```swift
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        ...
+        fpc.move(to: .half, animated: true)
+    }
+
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        ...
+        fpc.move(to: .full, animated: true)
+    }
+```
+
+### Make your contents correspond with a floating panel behavior
+
+```swift
+class ViewController: UIViewController, FloatingPanelControllerDelegate {
+    ...
+    func floatingPanelWillBeginDragging(_ vc: FloatingPanelController) {
+        if vc.position == .full {
+            searchVC.searchBar.showsCancelButton = false
+            searchVC.searchBar.resignFirstResponder()
+        }
+    }
+
+    func floatingPanelDidEndDragging(_ vc: FloatingPanelController, withVelocity velocity: CGPoint, targetPosition: FloatingPanelPosition) {
+        if targetPosition != .full {
+            searchVC.hideHeader()
+        }
+    }
+    ...
+}
+```
+
 ## Notes
 
-###  FloatingPanelSurfaceContentView
+###  FloatingPanelSurfaceView's issue on iOS 10
 
-* On iOS 10,   `FloatingPanelSurfaceContentView.cornerRadius` isn't not automatically masked with the top rounded corners  because of UIVisualEffectView issue. See https://forums.developer.apple.com/thread/50854. 
+* On iOS 10,   `FloatingPanelSurfaceView.cornerRadius` isn't not automatically masked with the top rounded corners  because of UIVisualEffectView issue. See https://forums.developer.apple.com/thread/50854. 
 So you need to draw top rounding corners of your content.  Here is an example in Examples/Maps.
-```
+```swift
 override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     if #available(iOS 10, *) {
@@ -231,7 +295,7 @@ override func viewDidLayoutSubviews() {
     }
 }
 ```
-* If you sets clear color to `FloatingPanelSurfaceContentView.backgrounColor`, please note the bottom overflow of your content on bouncing at full position. To prevent it, you need to expand your content. For example, See Example/Maps's Auto Layout settings of UIVisualEffectView in Main.storyborad.
+* If you sets clear color to `FloatingPanelSurfaceView.backgrounColor`, please note the bottom overflow of your content on bouncing at full position. To prevent it, you need to expand your content. For example, See Example/Maps's Auto Layout settings of UIVisualEffectView in Main.storyborad.
 
 ## Author
 


### PR DESCRIPTION
### Bugfixs
- The child view controller in `FloatingPanelController` can use the bottom of safe layout guide expectedly.
    - Modify `FloatingPanelController.adjustedContentInset` value
- Fix a critical bug on only full and half anchor position support
- Fix `FloatingPanelLayout.{topInteractionBuffer,bottomInteractionBuffer}`
- Modify Examples/Maps to fix a blank space and a clip of cells issue in #1.  Thank you, @jaimeealmanza!

### Improvements
- Improve the shadow layer of `FloatingPanelSurfaceView`
- Add a sample scene with TabBar in Samples.app.
- Update README
    - Add shields
    - Add TOC
    - Add Notes section
    - Update Usage section
