### PR TITLE
Improve public interface

### DIFF
--- a/Examples/Maps/Maps/ViewController.swift
+++ b/Examples/Maps/Maps/ViewController.swift
@@ -84,15 +84,16 @@ class ViewController: UIViewController, MKMapViewDelegate, UISearchBarDelegate, 
     // MARK: FloatingPanelControllerDelegate
     
     func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
-        switch traitCollection.verticalSizeClass {
+        switch newCollection.verticalSizeClass {
         case .compact:
             fpc.surfaceView.borderWidth = 1.0 / traitCollection.displayScale
             fpc.surfaceView.borderColor = UIColor.black.withAlphaComponent(0.2)
+            return SearchPanelLandscapeLayout()
         default:
             fpc.surfaceView.borderWidth = 0.0
             fpc.surfaceView.borderColor = nil
+            return nil
         }
-        return nil
     }
 
     func floatingPanelDidMove(_ vc: FloatingPanelController) {
@@ -200,6 +201,38 @@ class SearchPanelViewController: UIViewController, UITableViewDataSource, UITabl
             }
         }
         tableView.endUpdates()
+    }
+}
+
+public class SearchPanelLandscapeLayout: FloatingPanelLayout {
+    public var initialPosition: FloatingPanelPosition {
+        return .tip
+    }
+    
+    public var supportedPositions: Set<FloatingPanelPosition> {
+        return [.full, .tip]
+    }
+
+    public func insetFor(position: FloatingPanelPosition) -> CGFloat? {
+        switch position {
+        case .full: return 16.0
+        case .tip: return 69.0
+        default: return nil
+        }
+    }
+
+    public func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
+        if #available(iOS 11.0, *) {
+            return [
+                surfaceView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 8.0),
+                surfaceView.widthAnchor.constraint(equalToConstant: 291),
+            ]
+        } else {
+            return [
+                surfaceView.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 8.0),
+                surfaceView.widthAnchor.constraint(equalToConstant: 291),
+            ]
+        }
     }
 }
 

--- a/Examples/Samples/Sources/Base.lproj/Main.storyboard
+++ b/Examples/Samples/Sources/Base.lproj/Main.storyboard
@@ -189,14 +189,42 @@
                                     <action selector="closeWithSender:" destination="bYI-y3-Rzb" eventType="touchUpInside" id="MSC-ch-YJK"/>
                                 </connections>
                             </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="44" translatesAutoresizingMaskIntoConstraints="NO" id="9p4-06-y2T">
+                                <rect key="frame" x="145" y="108" width="85" height="178"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="i9x-x5-n1q">
+                                        <rect key="frame" x="0.0" y="0.0" width="80" height="30"/>
+                                        <state key="normal" title="Move to full"/>
+                                        <connections>
+                                            <action selector="moveToFullWithSender:" destination="bYI-y3-Rzb" eventType="touchUpInside" id="TDe-3J-gIR"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2u5-cH-RAN">
+                                        <rect key="frame" x="0.0" y="74" width="85" height="30"/>
+                                        <state key="normal" title="Move to half"/>
+                                        <connections>
+                                            <action selector="moveToHalfWithSender:" destination="bYI-y3-Rzb" eventType="touchUpInside" id="12s-o7-Et5"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M4A-iO-RIE">
+                                        <rect key="frame" x="0.0" y="148" width="77" height="30"/>
+                                        <state key="normal" title="Move to tip"/>
+                                        <connections>
+                                            <action selector="moveToTipWithSender:" destination="bYI-y3-Rzb" eventType="touchUpInside" id="BmL-91-9ai"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="sbF-Az-7sy" firstAttribute="top" secondItem="GBa-yx-8to" secondAttribute="top" id="3VR-hj-zeQ"/>
+                            <constraint firstItem="9p4-06-y2T" firstAttribute="top" secondItem="GBa-yx-8to" secondAttribute="top" constant="88" id="41n-Fn-hi3"/>
                             <constraint firstAttribute="bottom" secondItem="vut-mK-Y4t" secondAttribute="bottom" id="6eq-Kt-heZ"/>
                             <constraint firstItem="sbF-Az-7sy" firstAttribute="leading" secondItem="GBa-yx-8to" secondAttribute="leading" constant="20" id="T2G-1L-PRs"/>
                             <constraint firstItem="vut-mK-Y4t" firstAttribute="leading" secondItem="qwo-GK-p1U" secondAttribute="leading" id="gVC-jv-VJX"/>
                             <constraint firstItem="vut-mK-Y4t" firstAttribute="trailing" secondItem="GBa-yx-8to" secondAttribute="trailing" id="jkq-p2-lUm"/>
+                            <constraint firstItem="9p4-06-y2T" firstAttribute="centerX" secondItem="qwo-GK-p1U" secondAttribute="centerX" id="l8t-p3-ETf"/>
                             <constraint firstItem="vut-mK-Y4t" firstAttribute="top" secondItem="GBa-yx-8to" secondAttribute="bottom" id="rMy-JT-t4B"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="GBa-yx-8to"/>

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -373,7 +373,7 @@ class OneTabBarPanelLayout: FloatingPanelLayout {
     var initialPosition: FloatingPanelPosition {
         return .tip
     }
-    var supportedPositions: [FloatingPanelPosition] {
+    var supportedPositions: Set<FloatingPanelPosition> {
         return [.full, .tip]
     }
 
@@ -390,7 +390,7 @@ class TwoTabBarPanel2Layout: FloatingPanelLayout {
     var initialPosition: FloatingPanelPosition {
         return .half
     }
-    var supportedPositions: [FloatingPanelPosition] {
+    var supportedPositions: Set<FloatingPanelPosition> {
         return [.full, .half]
     }
     var bottomInteractionBuffer: CGFloat {

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -303,6 +303,16 @@ class ModalViewController: UIViewController {
     @IBAction func close(sender: UIButton) {
         dismiss(animated: true, completion: nil)
     }
+
+    @IBAction func moveToFull(sender: UIButton) {
+        fpc.move(to: .full, animated: true)
+    }
+    @IBAction func moveToHalf(sender: UIButton) {
+        fpc.move(to: .half, animated: true)
+    }
+    @IBAction func moveToTip(sender: UIButton) {
+        fpc.move(to: .tip, animated: true)
+    }
 }
 
 class TabBarViewController: UITabBarController {}

--- a/Examples/Stocks/Stocks/ViewController.swift
+++ b/Examples/Stocks/Stocks/ViewController.swift
@@ -102,10 +102,6 @@ class NewsViewController: UIViewController {
 // MARK: My custom layout
 
 class FloatingPanelStocksLayout: FloatingPanelLayout {
-    public var supportedPositions: [FloatingPanelPosition] {
-        return [.full, .half, .tip]
-    }
-
     var initialPosition: FloatingPanelPosition {
         return .tip
     }
@@ -119,13 +115,6 @@ class FloatingPanelStocksLayout: FloatingPanelLayout {
         case .half: return 262.0
         case .tip: return 85.0 + 44.0 // Visible + ToolView
         }
-    }
-
-    func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
-        return [
-            surfaceView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 0.0),
-            surfaceView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor, constant: 0.0),
-        ]
     }
 
     var backdropAlpha: CGFloat = 0.0

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -184,10 +184,17 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         guard gestureRecognizer == panGesture else { return false }
 
         // Do not begin the pan gesture until any other gestures fail except fo the tracking scrollView's pan gesture.
-        if otherGestureRecognizer == scrollView?.panGestureRecognizer {
+        switch otherGestureRecognizer {
+        case scrollView?.panGestureRecognizer:
             return false
-        } else {
+        case is UIPanGestureRecognizer,
+             is UISwipeGestureRecognizer,
+             is UIRotationGestureRecognizer,
+             is UIScreenEdgePanGestureRecognizer,
+             is UIPinchGestureRecognizer:
             return true
+        default:
+            return false
         }
     }
 

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -373,16 +373,16 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     private func targetPosition(with translation: CGPoint, velocity: CGPoint) -> (FloatingPanelPosition) {
         let currentY = getCurrentY(from: initialFrame, with: translation)
-        let supportedPositions = Set(layoutAdapter.layout.supportedPositions)
+        let supportedPositions: Set = layoutAdapter.layout.supportedPositions
 
         assert(supportedPositions.count > 1)
 
         switch supportedPositions {
-        case Set([.full, .half]):
+        case [.full, .half]:
             return targetPosition(from: [.full, .half], at: currentY, velocity: velocity)
-        case Set([.half, .tip]):
+        case [.half, .tip]:
             return targetPosition(from: [.half, .tip], at: currentY, velocity: velocity)
-        case Set([.full, .tip]):
+        case [.full, .tip]:
             return targetPosition(from: [.full, .tip], at: currentY, velocity: velocity)
         default:
             /*

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -35,8 +35,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     private(set) var state: FloatingPanelPosition = .tip
 
+    let panGesture: FloatingPanelPanGestureRecognizer
+
     private var animator: UIViewPropertyAnimator?
-    private let panGesture: UIPanGestureRecognizer
     private var initialFrame: CGRect = .zero
     private var transOffsetY: CGFloat = 0
     private var interactionInProgress: Bool = false
@@ -60,7 +61,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                                                         layout: layout)
         self.behavior = behavior
 
-        panGesture = UIPanGestureRecognizer()
+        panGesture = FloatingPanelPanGestureRecognizer()
 
         if #available(iOS 11.0, *) {
             panGesture.name = "FloatingPanelSurface"
@@ -491,6 +492,24 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             stopScrollDeceleration = false
         } else {
             userScrollViewDelegate?.scrollViewWillEndDragging?(scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset)
+        }
+    }
+}
+
+class FloatingPanelPanGestureRecognizer: UIPanGestureRecognizer {
+    override weak var delegate: UIGestureRecognizerDelegate? {
+        get {
+            return super.delegate
+        }
+        set {
+            guard newValue is FloatingPanel else {
+                let exception = NSException(name: .invalidArgumentException,
+                                            reason: "FloatingPanelController's built-in pan gesture recognizer must have its controller as its delegate.",
+                                            userInfo: nil)
+                exception.raise()
+                return
+            }
+            super.delegate = newValue
         }
     }
 }

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -6,21 +6,38 @@
 import UIKit
 
 public protocol FloatingPanelBehavior {
-    // Returns a UIViewPropertyAnimator object for interacting with a floating panel by a user pan gesture
+    /// Returns a UIViewPropertyAnimator object for interacting with a floating panel by a user pan gesture
     func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator
 
-    // Returns a UIViewPropertyAnimator object to present a floating panel
-    func presentAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> UIViewPropertyAnimator
-    // Returns a UIViewPropertyAnimator object to dismiss a floating panel
-    func dismissAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition) -> UIViewPropertyAnimator
+    /// Returns a UIViewPropertyAnimator object to add a floating panel to a position.
+    ///
+    /// Its animator instance will be used to animate the surface view in `FloatingPanelController.addPanel(toParent:belowView:animated:)`.
+    /// Default is an animator with ease-in-out curve and 0.25 sec duration.
+    func addAnimator(_ fpc: FloatingPanelController, to: FloatingPanelPosition) -> UIViewPropertyAnimator
+
+    /// Returns a UIViewPropertyAnimator object to remove a floating panel from a position.
+    ///
+    /// Its animator instance will be used to animate the surface view in `FloatingPanelController.removePanelFromParent(animated:completion:)`.
+    /// Default is an animator with ease-in-out curve and 0.25 sec duration.
+    func removeAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition) -> UIViewPropertyAnimator
+
+    /// Returns a UIViewPropertyAnimator object to move a floating panel from a position to a position.
+    ///
+    /// Its animator instance will be used to animate the surface view in `FloatingPanelController.move(to:animated:completion:)`.
+    /// Default is an animator with ease-in-out curve and 0.25 sec duration.
+    func moveAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> UIViewPropertyAnimator
 }
 
 public extension FloatingPanelBehavior {
-    func presentAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> UIViewPropertyAnimator {
+    func addAnimator(_ fpc: FloatingPanelController, to: FloatingPanelPosition) -> UIViewPropertyAnimator {
         return UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut)
     }
 
-    func dismissAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition) -> UIViewPropertyAnimator {
+    func removeAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition) -> UIViewPropertyAnimator {
+        return UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut)
+    }
+
+    func moveAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> UIViewPropertyAnimator {
         return UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut)
     }
 }

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -71,6 +71,11 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
         return floatingPanel.scrollView
     }
 
+    // The underlying gesture recognizer for pan gestures
+    public var panGestureRecognizer: UIPanGestureRecognizer {
+        return floatingPanel.panGesture
+    }
+
     /// The current position of the floating panel controller's contents.
     public var position: FloatingPanelPosition {
         return floatingPanel.state
@@ -90,11 +95,19 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+
+        floatingPanel = FloatingPanel(self,
+                                      layout: fetchLayout(for: self.traitCollection),
+                                      behavior: fetchBehavior(for: self.traitCollection))
     }
 
     /// Initialize a newly created floating panel controller.
     public init() {
         super.init(nibName: nil, bundle: nil)
+
+        floatingPanel = FloatingPanel(self,
+                                      layout: fetchLayout(for: self.traitCollection),
+                                      behavior: fetchBehavior(for: self.traitCollection))
     }
 
     /// Creates the view that the controller manages.
@@ -105,12 +118,6 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
         view.backgroundColor = .white
 
         self.view = view as UIView
-
-        let layout = fetchLayout(for: self.traitCollection)
-        let behavior = fetchBehavior(for: self.traitCollection)
-        floatingPanel = FloatingPanel(self,
-                                      layout: layout,
-                                      behavior: behavior)
     }
 
     public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -36,7 +36,7 @@ public extension FloatingPanelControllerDelegate {
     func floatingPanelDidEndDecelerating(_ vc: FloatingPanelController) {}
 }
 
-public enum FloatingPanelPosition: Int {
+public enum FloatingPanelPosition: Int, CaseIterable {
     case full
     case half
     case tip

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -6,10 +6,10 @@
 import UIKit
 
 public protocol FloatingPanelLayout: class {
-    /// Returns the initial position of a floating panel
+    /// Returns the initial position of a floating panel.
     var initialPosition: FloatingPanelPosition { get }
 
-    /// Returns an array of FloatingPanelPosition objects to tell the applicable positions of the floating panel controller
+    /// Returns an array of FloatingPanelPosition objects to tell the applicable positions of the floating panel controller. Default is all of them.
     var supportedPositions: [FloatingPanelPosition] { get }
 
     /// Return the interaction buffer to the top from the top position. Default is 6.0.
@@ -27,6 +27,7 @@ public protocol FloatingPanelLayout: class {
     /// Returns X-axis and width layout constraints of the surface view of a floating panel.
     /// You must not include any Y-axis and height layout constraints of the surface view
     /// because their constraints will be configured by the floating panel controller.
+    /// By default, the width of a surface view fits a safe area.
     func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint]
 
     /// Return the backdrop alpha of black color in full position. Default is 0.3.
@@ -37,13 +38,20 @@ public extension FloatingPanelLayout {
     var backdropAlpha: CGFloat { return 0.3 }
     var topInteractionBuffer: CGFloat { return 6.0 }
     var bottomInteractionBuffer: CGFloat { return 6.0 }
-}
 
-public class FloatingPanelDefaultLayout: FloatingPanelLayout {
     public var supportedPositions: [FloatingPanelPosition] {
         return [.full, .half, .tip]
     }
+    
+    func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
+        return [
+            surfaceView.leftAnchor.constraint(equalTo: view.sideLayoutGuide.leftAnchor, constant: 0.0),
+            surfaceView.rightAnchor.constraint(equalTo: view.sideLayoutGuide.rightAnchor, constant: 0.0),
+        ]
+    }
+}
 
+public class FloatingPanelDefaultLayout: FloatingPanelLayout {
     public var initialPosition: FloatingPanelPosition {
         return .half
     }
@@ -54,13 +62,6 @@ public class FloatingPanelDefaultLayout: FloatingPanelLayout {
         case .half: return 262.0
         case .tip: return 69.0
         }
-    }
-
-    public func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
-        return [
-            surfaceView.leftAnchor.constraint(equalTo: view.sideLayoutGuide.leftAnchor, constant: 0.0),
-            surfaceView.rightAnchor.constraint(equalTo: view.sideLayoutGuide.rightAnchor, constant: 0.0),
-        ]
     }
 }
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -83,9 +83,9 @@ public class FloatingPanelDefaultLandscapeLayout: FloatingPanelLayout {
 
     public func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
         return [
-            surfaceView.leftAnchor.constraint(equalTo: view.sideLayoutGuide.leftAnchor, constant: 8.0),
-            surfaceView.widthAnchor.constraint(equalToConstant: 291),
-            ]
+            surfaceView.leftAnchor.constraint(equalTo: view.sideLayoutGuide.leftAnchor, constant: 0.0),
+            surfaceView.rightAnchor.constraint(equalTo: view.sideLayoutGuide.rightAnchor, constant: 0.0),
+        ]
     }
 }
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -9,8 +9,8 @@ public protocol FloatingPanelLayout: class {
     /// Returns the initial position of a floating panel.
     var initialPosition: FloatingPanelPosition { get }
 
-    /// Returns an array of FloatingPanelPosition objects to tell the applicable positions of the floating panel controller. Default is all of them.
-    var supportedPositions: [FloatingPanelPosition] { get }
+    /// Returns a set of FloatingPanelPosition objects to tell the applicable positions of the floating panel controller. Default is all of them.
+    var supportedPositions: Set<FloatingPanelPosition> { get }
 
     /// Return the interaction buffer to the top from the top position. Default is 6.0.
     var topInteractionBuffer: CGFloat { get }
@@ -39,8 +39,8 @@ public extension FloatingPanelLayout {
     var topInteractionBuffer: CGFloat { return 6.0 }
     var bottomInteractionBuffer: CGFloat { return 6.0 }
 
-    public var supportedPositions: [FloatingPanelPosition] {
-        return [.full, .half, .tip]
+    public var supportedPositions: Set<FloatingPanelPosition> {
+        return Set(FloatingPanelPosition.allCases)
     }
     
     func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
@@ -69,7 +69,7 @@ public class FloatingPanelDefaultLandscapeLayout: FloatingPanelLayout {
     public var initialPosition: FloatingPanelPosition {
         return .tip
     }
-    public var supportedPositions: [FloatingPanelPosition] {
+    public var supportedPositions: Set<FloatingPanelPosition> {
         return [.full, .tip]
     }
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -94,7 +94,9 @@ class FloatingPanelLayoutAdapter {
     private weak var surfaceView: FloatingPanelSurfaceView!
     private weak var backdropVIew: FloatingPanelBackdropView!
 
-    var layout: FloatingPanelLayout
+    var layout: FloatingPanelLayout {
+        didSet { checkConsistance(of: layout) }
+    }
 
     var safeAreaInsets: UIEdgeInsets = .zero {
         didSet {
@@ -162,13 +164,6 @@ class FloatingPanelLayoutAdapter {
         self.layout = layout
         self.surfaceView = surfaceView
         self.backdropVIew = backdropView
-
-        // Verify layout configurations
-        assert(layout.supportedPositions.count > 1)
-        assert(layout.supportedPositions.contains(layout.initialPosition))
-        if halfInset > 0 {
-            assert(halfInset >= tipInset)
-        }
     }
 
     func prepareLayout(toParent parent: UIViewController) {
@@ -258,6 +253,24 @@ class FloatingPanelLayoutAdapter {
         case .tip:
             NSLayoutConstraint.deactivate(fullConstraints + halfConstraints + offConstraints)
             NSLayoutConstraint.activate(tipConstraints)
+        }
+    }
+
+    private func checkConsistance(of layout: FloatingPanelLayout) {
+        // Verify layout configurations
+        assert(layout.supportedPositions.count > 1)
+        assert(layout.supportedPositions.contains(layout.initialPosition),
+               "Does not include an initial potision(\(layout.initialPosition)) in supportedPositions(\(layout.supportedPositions))")
+        layout.supportedPositions.forEach { (pos) in
+            assert(layout.insetFor(position: pos) != nil,
+                   "Undefined an inset for a pos(\(pos))")
+        }
+        if halfInset > 0 {
+            assert(halfInset > tipInset, "Invalid half and tip insets")
+        }
+        if fullInset > 0 {
+            assert(middleY > topY, "Invalid insets")
+            assert(bottomY > topY, "Invalid insets")
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 
 ### Customize the layout of a floating panel with  `FloatingPanelLayout` protocol
 
-#### Change the initial position, supported positions and height
+#### Change the initial position and height
 
 ```swift
 class ViewController: UIViewController, FloatingPanelControllerDelegate {
@@ -135,9 +135,6 @@ class MyFloatingPanelLayout: FloatingPanelLayout {
     public var initialPosition: FloatingPanelPosition {
         return .tip
     }
-    public var supportedPositions: [FloatingPanelPosition] {
-        return [.full, .half, .tip]
-    }
 
     public func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
@@ -145,13 +142,6 @@ class MyFloatingPanelLayout: FloatingPanelLayout {
             case .half: return 216.0 // A bottom inset from the safe area
             case .tip: return 44.0 // A bottom inset from the safe area
         }
-    }
-
-    func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
-        return [
-            surfaceView.leftAnchor.constraint(equalTo: view.sideLayoutGuide.leftAnchor, constant: 0.0),
-            surfaceView.rightAnchor.constraint(equalTo: view.sideLayoutGuide.rightAnchor, constant: 0.0),
-        ]
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ class MyFloatingPanelLayout: FloatingPanelLayout {
 
     public func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
-            case .full: return 16.0 # A top inset from safe area
-            case .half: return 216.0 # A bottom inset from the safe area
-            case .tip: return 44.0 # A bottom inset from the safe area
+            case .full: return 16.0 // A top inset from safe area
+            case .half: return 216.0 // A bottom inset from the safe area
+            case .tip: return 44.0 // A bottom inset from the safe area
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ class FloatingPanelLandscapeLayout: FloatingPanelLayout {
     public var initialPosition: FloatingPanelPosition {
         return .tip
     }
-    public var supportedPositions: [FloatingPanelPosition] {
+    public var supportedPositions: Set<FloatingPanelPosition> {
         return [.full, .tip]
     }
 


### PR DESCRIPTION
FloatingPanelLayout
- Add FloatingPanelLayout default implementations to make it easy to create a custom FloatingPanelLayout object
- Change `FloatingPanelLayout .supportedPositiions` type from Array to Set
```diff
- var supportedPositions: [FloatingPanelPosition]
+ var supportedPositions: Set<FloatingPanelPosition>
```
- Add `FloatingPanelLayout` consistence check
- Change the default landscape layout to reslove #3

FloatingPanelController
- Open a pan gesture of FloatingPanelController as `FloatingPanelController.panGestureRecognizer`
- Fix failure requirements of the pan gesture

FloatingPanelBehavior
- Modify and Improve FloatingPanelBehavior protocol to be more clear.
     - "present" and "dismiss" should be used for modality by convention of UIViewController. so "add" and "remove" are appropriate for them.

```diff
- func presentAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> UIViewPropertyAnimator 
+ func addAnimator(_ fpc: FloatingPanelController, to: FloatingPanelPosition) -> UIViewPropertyAnimator 

-  func dismissAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition) -> UIViewPropertyAnimator
+ func removeAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition) -> UIViewPropertyAnimator

+ func moveAnimator(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> UIViewPropertyAnimator
```