### PR TITLE
Fix show segue problem

### DIFF
--- a/Examples/Maps/Maps/ViewController.swift
+++ b/Examples/Maps/Maps/ViewController.swift
@@ -26,8 +26,8 @@ class ViewController: UIViewController, MKMapViewDelegate, UISearchBarDelegate, 
 
         searchVC = storyboard?.instantiateViewController(withIdentifier: "SearchPanel") as? SearchPanelViewController
 
-        // Add a content view controller
-        fpc.show(searchVC, sender: self)
+        // Set a content view controller
+        fpc.set(contentViewController: searchVC)
         fpc.track(scrollView: searchVC.tableView)
 
         setupMapView()

--- a/Examples/Samples/Sources/Base.lproj/Main.storyboard
+++ b/Examples/Samples/Sources/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RoN-h0-uBD">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RoN-h0-uBD">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -356,7 +356,7 @@
                     </connections>
                 </swipeGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1239" y="806"/>
+            <point key="canvasLocation" x="1311" y="806"/>
         </scene>
         <!--Detail View Controller-->
         <scene sceneID="b6k-zi-3wn">
@@ -390,14 +390,36 @@
                                     <constraint firstAttribute="height" constant="44" id="DQJ-cY-cKx"/>
                                 </constraints>
                             </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="tP3-oJ-4EB">
+                                <rect key="frame" x="130.5" y="108" width="114" height="82"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c5r-jU-haj">
+                                        <rect key="frame" x="0.0" y="0.0" width="114" height="30"/>
+                                        <state key="normal" title="Show"/>
+                                        <connections>
+                                            <action selector="buttonPressed:" destination="YC8-ae-15L" eventType="touchUpInside" id="Mi1-o6-TWt"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wmd-ab-Nz3">
+                                        <rect key="frame" x="0.0" y="52" width="114" height="30"/>
+                                        <state key="normal" title="Present Modallly"/>
+                                        <connections>
+                                            <action selector="buttonPressed:" destination="YC8-ae-15L" eventType="touchUpInside" id="tjH-Ev-kpx"/>
+                                            <segue destination="bYI-y3-Rzb" kind="presentation" identifier="PresentModallySegue" id="3yq-HE-Tgn"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="noi-1a-5bZ" firstAttribute="top" secondItem="g7l-kO-y7q" secondAttribute="top" constant="12" id="EQy-cr-F2Y"/>
+                            <constraint firstItem="tP3-oJ-4EB" firstAttribute="centerX" secondItem="g7l-kO-y7q" secondAttribute="centerX" id="EsD-Vf-dNZ"/>
                             <constraint firstItem="8yw-OC-Ubk" firstAttribute="bottom" secondItem="g7l-kO-y7q" secondAttribute="bottom" id="JOL-wC-w74"/>
                             <constraint firstItem="8yw-OC-Ubk" firstAttribute="leading" secondItem="tAi-nk-rDB" secondAttribute="leading" id="RiJ-Hb-OOZ"/>
                             <constraint firstItem="8yw-OC-Ubk" firstAttribute="trailing" secondItem="tAi-nk-rDB" secondAttribute="trailing" id="Sof-yL-mwK"/>
+                            <constraint firstItem="tP3-oJ-4EB" firstAttribute="top" secondItem="tAi-nk-rDB" secondAttribute="top" constant="88" id="Zhb-Ss-epe"/>
                             <constraint firstItem="Kva-Z7-0qY" firstAttribute="trailing" secondItem="tAi-nk-rDB" secondAttribute="trailing" id="kkp-Yo-FQW"/>
                             <constraint firstItem="tAi-nk-rDB" firstAttribute="trailing" secondItem="noi-1a-5bZ" secondAttribute="trailing" constant="12" id="lv9-Nf-HNB"/>
                             <constraint firstItem="Kva-Z7-0qY" firstAttribute="leading" secondItem="tAi-nk-rDB" secondAttribute="leading" id="oVC-i1-TwS"/>
@@ -413,6 +435,7 @@
                     <size key="freeformSize" width="375" height="778"/>
                     <connections>
                         <outlet property="closeButton" destination="noi-1a-5bZ" id="eWQ-ha-8y7"/>
+                        <segue destination="bYI-y3-Rzb" kind="show" identifier="ShowSegue" id="r1P-2i-NDe"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Wqk-xl-O3I" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -432,7 +455,7 @@
                     </connections>
                 </pongPressGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1442" y="-23"/>
+            <point key="canvasLocation" x="1440.8" y="-23.388305847076463"/>
         </scene>
         <!--Debug Text View Controller-->
         <scene sceneID="Bkq-O7-q4A">
@@ -507,4 +530,7 @@ Section 1.10.33 of "de Finibus Bonorum et Malorum", written by Cicero in 45 BC
             <point key="canvasLocation" x="729" y="-23"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="3yq-HE-Tgn"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -70,9 +70,10 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
         mainPanelVC.surfaceView.cornerRadius = 6.0
         mainPanelVC.surfaceView.shadowHidden = false
 
-        // Add a content view controller and connect with the scroll view
-        mainPanelVC.show(contentVC, sender: self)
+        // Set a content view controller
+        mainPanelVC.set(contentViewController: contentVC)
 
+        // Track a scroll view
         switch contentVC {
         case let consoleVC as DebugTextViewController:
             mainPanelVC.track(scrollView: consoleVC.textView)
@@ -128,10 +129,8 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             detailPanelVC.surfaceView.cornerRadius = 6.0
             detailPanelVC.surfaceView.shadowHidden = false
 
-            // Add a content view controller and connect with the scroll view
-            detailPanelVC.show(contentVC, sender: self)
-
-            // (contentVC as? DetailViewController)?.closeButton?.addTarget(self, action: #selector(dismissDetailPanelVC), for: .touchUpInside)
+            // Set a content view controller
+            detailPanelVC.set(contentViewController: contentVC)
 
             //  Add FloatingPanel to self.view
             detailPanelVC.addPanel(toParent: self, belowView: nil, animated: true)
@@ -299,6 +298,18 @@ class DetailViewController: UIViewController {
         // dismiss(animated: true, completion: nil)
         (self.parent as? FloatingPanelController)?.removePanelFromParent(animated: true, completion: nil)
     }
+
+    @IBAction func buttonPressed(_ sender: UIButton) {
+        switch sender.titleLabel?.text {
+        case "Show":
+            performSegue(withIdentifier: "ShowSegue", sender: self)
+        case "Present Modally":
+            performSegue(withIdentifier: "PresentModallySegue", sender: self)
+        default:
+            break
+        }
+    }
+
     @IBAction func tapped(_ sender: Any) {
         print("Detail panel is tapped!")
     }
@@ -323,11 +334,12 @@ class ModalViewController: UIViewController {
         fpc.surfaceView.cornerRadius = 6.0
         fpc.surfaceView.shadowHidden = false
 
-        // Add a content view controller and connect with the scroll view
+        // Set a content view controller and track the scroll view
         let consoleVC = storyboard?.instantiateViewController(withIdentifier: "ConsoleViewController") as! DebugTextViewController
-        fpc.show(consoleVC, sender: self)
-        self.consoleVC = consoleVC
+        fpc.set(contentViewController: consoleVC)
         fpc.track(scrollView: consoleVC.textView)
+
+        self.consoleVC = consoleVC
 
         //  Add FloatingPanel to self.view
         fpc.addPanel(toParent: self, belowView: safeAreaView)
@@ -370,11 +382,11 @@ class TabBarContentViewController: UIViewController, FloatingPanelControllerDele
         fpc.surfaceView.cornerRadius = 6.0
         fpc.surfaceView.shadowHidden = false
 
-        // Add a content view controller and connect with the scroll view
+        // Set a content view controller and track the scroll view
         let consoleVC = storyboard?.instantiateViewController(withIdentifier: "ConsoleViewController") as! DebugTextViewController
-        fpc.show(consoleVC, sender: self)
-        self.consoleVC = consoleVC
+        fpc.set(contentViewController: consoleVC)
         fpc.track(scrollView: consoleVC.textView)
+        self.consoleVC = consoleVC
 
         //  Add FloatingPanel to self.view
         fpc.addPanel(toParent: self)

--- a/Examples/Stocks/Stocks/ViewController.swift
+++ b/Examples/Stocks/Stocks/ViewController.swift
@@ -34,8 +34,8 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 
         newsVC = storyboard?.instantiateViewController(withIdentifier: "News") as? NewsViewController
 
-        // Add a content view controller
-        fpc.show(newsVC, sender: self)
+        // Set a content view controller
+        fpc.set(contentViewController: newsVC)
         fpc.track(scrollView: newsVC.scrollView)
 
         fpc.addPanel(toParent: self, belowView: bottomToolView, animated: false)

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -97,6 +97,13 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
         get { return floatingPanel.isRemovalInteractionEnabled }
     }
 
+    /// The view controller responsible for the content portion of the floating panel.
+    public var contentViewController: UIViewController? {
+        set { set(contentViewController: newValue) }
+        get { return _contentViewController }
+    }
+    private var _contentViewController: UIViewController?
+
     private var floatingPanel: FloatingPanel!
 
     required init?(coder aDecoder: NSCoder) {
@@ -252,20 +259,44 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
         floatingPanel.move(to: to, animated: animated, completion: completion)
     }
 
-    /// Presents the specified view controller as the content view controller in the surface view interface.
+    /// Sets the view controller responsible for the content portion of the floating panel..
+    public func set(contentViewController: UIViewController?) {
+        if let vc = _contentViewController {
+            vc.willMove(toParent: nil)
+            vc.view.removeFromSuperview()
+            vc.removeFromParent()
+        }
+
+        if let vc = contentViewController {
+            let surfaceView = self.view as! FloatingPanelSurfaceView
+            surfaceView.contentView.addSubview(vc.view)
+            vc.view.frame = surfaceView.contentView.bounds
+            vc.view.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                vc.view.topAnchor.constraint(equalTo: surfaceView.contentView.topAnchor, constant: 0.0),
+                vc.view.leftAnchor.constraint(equalTo: surfaceView.contentView.leftAnchor, constant: 0.0),
+                vc.view.rightAnchor.constraint(equalTo: surfaceView.contentView.rightAnchor, constant: 0.0),
+                vc.view.bottomAnchor.constraint(equalTo: surfaceView.contentView.bottomAnchor, constant: 0.0),
+                ])
+            addChild(vc)
+            vc.didMove(toParent: self)
+        }
+
+        _contentViewController = contentViewController
+    }
+
+    @available(*, unavailable, renamed: "set(contentViewController:)")
     public override func show(_ vc: UIViewController, sender: Any?) {
-        let surfaceView = self.view as! FloatingPanelSurfaceView
-        surfaceView.contentView.addSubview(vc.view)
-        vc.view.frame = surfaceView.contentView.bounds
-        vc.view.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            vc.view.topAnchor.constraint(equalTo: surfaceView.contentView.topAnchor, constant: 0.0),
-            vc.view.leftAnchor.constraint(equalTo: surfaceView.contentView.leftAnchor, constant: 0.0),
-            vc.view.rightAnchor.constraint(equalTo: surfaceView.contentView.rightAnchor, constant: 0.0),
-            vc.view.bottomAnchor.constraint(equalTo: surfaceView.contentView.bottomAnchor, constant: 0.0),
-            ])
-        addChild(vc)
-        vc.didMove(toParent: self)
+        if let target = self.parent?.targetViewController(forAction: #selector(UIViewController.show(_:sender:)), sender: sender) {
+            target.show(vc, sender: sender)
+        }
+    }
+
+    @available(*, unavailable, renamed: "set(contentViewController:)")
+    public override func showDetailViewController(_ vc: UIViewController, sender: Any?) {
+        if let target = self.parent?.targetViewController(forAction: #selector(UIViewController.showDetailViewController(_:sender:)), sender: sender) {
+            target.showDetailViewController(vc, sender: sender)
+        }
     }
 
     // MARK: - Scroll view tracking


### PR DESCRIPTION
Fix #20 

`FloatingPanelController.show(_:sender)` is confusing. I don’t expect to work Show segues from a floating panel and I don't think it should work. So I'd like to deprecate the method on this PR, and replace it with `FloatingPanelController.set(contentViewController:)`. The change is planning to be merged into v1.2.0.

```diff
- fpc.show(contentVC, sender: nil)
+ fpc.set(contentViewController: contentVC)
```

~If you use "Show" or "Show Detail" segue from a floating panel, it will raise a fatal error.~

"Show" or "Show Detail" segue from a content VC of a floating panel will be handled by a view controller managing a floating panel.

Finally, `FloatingPanelController.set(contentViewController:)` might be updated to `FloatingPanelController.set(contentViewController:animated:)` to replace a content view with an animation.