### PR TITLE
Add a removable interaction

### DIFF
--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import FloatingPanel
 
-class SampleListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+class SampleListViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, FloatingPanelControllerDelegate {
     @IBOutlet weak var tableView: UITableView!
 
     enum Menu: Int, CaseIterable {
@@ -19,6 +19,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
         case showModal
         case showTabBar
         case showNestedScrollView
+        case showRemovablePanel
 
         var name: String {
             switch self {
@@ -28,6 +29,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             case .showModal: return "Show Modal"
             case .showTabBar: return "Show Tab Bar"
             case .showNestedScrollView: return "Show Nested ScrollView"
+            case .showRemovablePanel: return "Show Removable Panel"
             }
         }
 
@@ -39,12 +41,14 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             case .showModal: return "ModalViewController"
             case .showTabBar: return "TabBarViewController"
             case .showNestedScrollView: return "NestedScrollViewController"
+            case .showRemovablePanel: return "DetailViewController"
             }
         }
     }
 
     var mainPanelVC: FloatingPanelController!
     var detailPanelVC: FloatingPanelController!
+    var currentMenu: Menu = .trackingTableView
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -59,6 +63,8 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
     func addMainPanel(with contentVC: UIViewController) {
         // Initialize FloatingPanelController
         mainPanelVC = FloatingPanelController()
+        mainPanelVC.delegate = self
+        mainPanelVC.isRemovalInteractionEnabled = (currentMenu == .showRemovablePanel)
 
         // Initialize FloatingPanelController and add the view
         mainPanelVC.surfaceView.cornerRadius = 6.0
@@ -109,6 +115,8 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             return vc
         }()
 
+        self.currentMenu = menu
+
         switch menu {
         case .showDetail:
             detailPanelVC?.removeFromParent()
@@ -135,6 +143,14 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             mainPanelVC?.removePanelFromParent(animated: true) {
                 self.addMainPanel(with: contentVC)
             }
+        }
+    }
+
+    func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
+        if currentMenu == .showRemovablePanel {
+            return TwoTabBarPanel2Layout()
+        } else {
+            return nil
         }
     }
 }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -408,7 +408,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         let currentY = getCurrentY(from: initialFrame, with: translation)
         let supportedPositions: Set = layoutAdapter.layout.supportedPositions
 
-        assert(supportedPositions.count > 1)
+        if supportedPositions.count == 1 {
+            return state
+        }
 
         switch supportedPositions {
         case [.full, .half]:

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -91,6 +91,12 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     /// This property specifies how the content area of the tracking scroll view is modified using `adjustedContentInsets`. The default value of this property is FloatingPanelController.ContentInsetAdjustmentBehavior.always.
     public var contentInsetAdjustmentBehavior: ContentInsetAdjustmentBehavior = .always
 
+    /// A Boolean value that determines whether the removal interaction is enabled.
+    public var isRemovalInteractionEnabled: Bool {
+        set { floatingPanel.isRemovalInteractionEnabled = newValue }
+        get { return floatingPanel.isRemovalInteractionEnabled }
+    }
+
     private var floatingPanel: FloatingPanel!
 
     required init?(coder aDecoder: NSCoder) {
@@ -208,6 +214,9 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
         // Must set a layout again here because `self.traitCollection` is applied correctly once it's added to a parent VC
         floatingPanel.layoutAdapter.layout = fetchLayout(for: traitCollection)
         floatingPanel.layoutViews(in: parent)
+
+        floatingPanel.behavior = fetchBehavior(for: traitCollection)
+
         floatingPanel.present(animated: animated) { [weak self] in
             guard let self = self else { return }
             self.didMove(toParent: parent)

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -258,7 +258,7 @@ class FloatingPanelLayoutAdapter {
 
     private func checkConsistance(of layout: FloatingPanelLayout) {
         // Verify layout configurations
-        assert(layout.supportedPositions.count > 1)
+        assert(layout.supportedPositions.count > 0)
         assert(layout.supportedPositions.contains(layout.initialPosition),
                "Does not include an initial potision(\(layout.initialPosition)) in supportedPositions(\(layout.supportedPositions))")
         layout.supportedPositions.forEach { (pos) in

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -258,13 +258,17 @@ class FloatingPanelLayoutAdapter {
 
     private func checkConsistance(of layout: FloatingPanelLayout) {
         // Verify layout configurations
-        assert(layout.supportedPositions.count > 0)
-        assert(layout.supportedPositions.contains(layout.initialPosition),
-               "Does not include an initial potision(\(layout.initialPosition)) in supportedPositions(\(layout.supportedPositions))")
-        layout.supportedPositions.forEach { (pos) in
+        let supportedPositions = layout.supportedPositions
+
+        assert(supportedPositions.count > 0)
+        assert(supportedPositions.contains(layout.initialPosition),
+               "Does not include an initial potision(\(layout.initialPosition)) in supportedPositions(\(supportedPositions))")
+
+        supportedPositions.forEach { pos in
             assert(layout.insetFor(position: pos) != nil,
                    "Undefined an inset for a pos(\(pos))")
         }
+
         if halfInset > 0 {
             assert(halfInset > tipInset, "Invalid half and tip insets")
         }


### PR DESCRIPTION
Fix #8 

Add a removal interaction invoked when a floating pane is at the bottom position.

New APIs

- `FloatingPanelController.isRemovalInteractionEnabled`
- `FloatingPanelBehavior.removalVelocityThreshold`
- `removalInteractionAnimator(_:with)`

Changes

- Now FloatingPanelController allows to display a floating panel on only one position.