### PR TITLE
Fix moving floating panel without scrolling to top of scroll view

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -222,14 +222,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         switch panGesture {
         case scrollView?.panGestureRecognizer:
             guard let scrollView = scrollView else { return }
-            if panGesture.state == .began {
-                initialScrollOffset = scrollView.contentOffset
-            }
             if surfaceView.frame.minY > layoutAdapter.topY {
                 switch state {
                 case .full:
                     // Prevent over scrolling from scroll top in moving the panel from full.
-                    scrollView.contentOffset.y = initialScrollOffset.y
+                    scrollView.contentOffset.y = scrollView.contentOffsetZero.y
                 case .half, .tip:
                     guard scrollView.isDecelerating == false else {
                         // Don't fix the scroll offset in animating the panel to half and tip.
@@ -358,6 +355,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     private func startInteraction(with translation: CGPoint) {
         log.debug("startInteraction")
         initialFrame = surfaceView.frame
+        if let scrollView = scrollView {
+            initialScrollOffset = scrollView.contentOffset
+        }
         transOffsetY = translation.y
         viewcontroller.delegate?.floatingPanelWillBeginDragging(viewcontroller)
 

--- a/Framework/Sources/GrabberHandleView.swift
+++ b/Framework/Sources/GrabberHandleView.swift
@@ -24,8 +24,14 @@ public class GrabberHandleView: UIView {
         self.backgroundColor = Default.barColor
         render()
     }
+
     private func render() {
         self.layer.masksToBounds = true
         self.layer.cornerRadius = frame.size.height * 0.5
+    }
+
+    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+        return view == self ? nil : view
     }
 }


### PR DESCRIPTION
As discussed in #30, this PR resolves the issue of not being able to close the floating panel when the tracked scrollview is not at its top position.