### PR TITLE
Allow panel to be added to a subview of the view controller

### DIFF
--- a/Examples/Samples/Sources/Base.lproj/Main.storyboard
+++ b/Examples/Samples/Sources/Base.lproj/Main.storyboard
@@ -152,6 +152,60 @@
             </objects>
             <point key="canvasLocation" x="-380" y="1576"/>
         </scene>
+        <!--Subview Controller-->
+        <scene sceneID="pmZ-Fb-BUw">
+            <objects>
+                <viewController storyboardIdentifier="SubviewController" id="ctE-GA-hO5" customClass="SubviewController" customModule="Samples" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5jP-X6-bZd">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y2L-HE-R4g">
+                                <rect key="frame" x="0.0" y="20" width="375" height="603"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fje-gl-jo0">
+                                        <rect key="frame" x="8" y="48" width="39" height="30"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Close"/>
+                                        <connections>
+                                            <action selector="closeWithSender:" destination="ctE-GA-hO5" eventType="touchUpInside" id="FGn-jp-Oca"/>
+                                            <action selector="closeWithSender:" destination="lto-Zc-Vtp" eventType="touchUpInside" id="Fwh-EW-0Sf"/>
+                                            <action selector="closeWithSender:" destination="bYI-y3-Rzb" eventType="touchUpInside" id="fwm-bM-Zhx"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JE5-Xz-FIm">
+                                <rect key="frame" x="0.0" y="623" width="375" height="44"/>
+                                <items>
+                                    <barButtonItem title="Item" id="OeU-VX-T01"/>
+                                    <barButtonItem title="Item" id="XFa-G1-2oV"/>
+                                    <barButtonItem title="Item" id="8Eu-CK-5Ax"/>
+                                    <barButtonItem title="Item" id="z8W-oe-1zS"/>
+                                </items>
+                            </toolbar>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="y2L-HE-R4g" firstAttribute="trailing" secondItem="5jP-X6-bZd" secondAttribute="trailing" id="6uy-SG-Na3"/>
+                            <constraint firstItem="U5N-lv-s3Z" firstAttribute="bottom" secondItem="JE5-Xz-FIm" secondAttribute="bottom" id="NNc-xL-j0U"/>
+                            <constraint firstItem="JE5-Xz-FIm" firstAttribute="top" secondItem="y2L-HE-R4g" secondAttribute="bottom" id="PQJ-Te-Zob"/>
+                            <constraint firstItem="JE5-Xz-FIm" firstAttribute="leading" secondItem="5jP-X6-bZd" secondAttribute="leading" id="d3a-hE-lAR"/>
+                            <constraint firstItem="JE5-Xz-FIm" firstAttribute="trailing" secondItem="5jP-X6-bZd" secondAttribute="trailing" id="hWQ-bR-fnv"/>
+                            <constraint firstItem="y2L-HE-R4g" firstAttribute="top" secondItem="U5N-lv-s3Z" secondAttribute="top" id="ifu-ML-dIJ"/>
+                            <constraint firstItem="y2L-HE-R4g" firstAttribute="leading" secondItem="5jP-X6-bZd" secondAttribute="leading" id="kKl-5v-J7j"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="U5N-lv-s3Z"/>
+                    </view>
+                    <connections>
+                        <outlet property="containerView" destination="y2L-HE-R4g" id="z6V-b3-rcV"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Q5C-KO-rHE" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-380" y="2264.617691154423"/>
+        </scene>
         <!--Tab Bar View Controller-->
         <scene sceneID="nQ5-PV-qFw">
             <objects>

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -20,6 +20,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
         case showTabBar
         case showNestedScrollView
         case showRemovablePanel
+        case showFromSubview
 
         var name: String {
             switch self {
@@ -30,6 +31,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             case .showTabBar: return "Show Tab Bar"
             case .showNestedScrollView: return "Show Nested ScrollView"
             case .showRemovablePanel: return "Show Removable Panel"
+            case .showFromSubview: return "Show from subview"
             }
         }
 
@@ -42,6 +44,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             case .showTabBar: return "TabBarViewController"
             case .showNestedScrollView: return "NestedScrollViewController"
             case .showRemovablePanel: return "DetailViewController"
+            case .showFromSubview: return "SubviewController"
             }
         }
     }
@@ -134,7 +137,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
 
             //  Add FloatingPanel to self.view
             detailPanelVC.addPanel(toParent: self, belowView: nil, animated: true)
-        case .showModal, .showTabBar:
+        case .showModal, .showTabBar, .showFromSubview:
             let modalVC = contentVC
             present(modalVC, animated: true, completion: nil)
         default:
@@ -467,6 +470,46 @@ class TabBarContentViewController: UIViewController, FloatingPanelControllerDele
     }
 }
 
+class SubviewController: UIViewController, FloatingPanelControllerDelegate {
+    var fpc: FloatingPanelController!
+    var consoleVC: DebugTextViewController!
+    @IBOutlet var containerView: UIView!
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Initialize FloatingPanelController
+        fpc = FloatingPanelController()
+        fpc.delegate = self
+        
+        // Initialize FloatingPanelController and add the view
+        fpc.surfaceView.cornerRadius = 6.0
+        fpc.surfaceView.shadowHidden = false
+        
+        // Set a content view controller and track the scroll view
+        let consoleVC = storyboard?.instantiateViewController(withIdentifier: "ConsoleViewController") as! DebugTextViewController
+        fpc.set(contentViewController: consoleVC)
+        fpc.track(scrollView: consoleVC.textView)
+        self.consoleVC = consoleVC
+        
+        //  Add FloatingPanel to self.view
+        fpc.addPanel(toParent: self, containerView: containerView)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        //  Remove FloatingPanel from a view
+        fpc.removePanelFromParent(animated: false)
+    }
+    
+    func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
+        return OneTabBarPanelLayout()
+    }
+    
+    @IBAction func close(sender: UIButton) {
+        dismiss(animated: true, completion: nil)
+    }
+}
+
 extension FloatingPanelLayout {
     func prepareLayout(surfaceView: UIView, in view: UIView) -> [NSLayoutConstraint] {
         if #available(iOS 11.0, *) {
@@ -519,3 +562,4 @@ class TwoTabBarPanel2Layout: FloatingPanelLayout {
         }
     }
 }
+

--- a/FloatingPanel.podspec
+++ b/FloatingPanel.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                = "FloatingPanel"
-  s.version             = "1.1.0"
+  s.version             = "1.2.0"
   s.summary             = "FloatingPanel is a simple and easy-to-use UI component of a floating panel interface"
   s.description         = <<-DESC
 FloatingPanel is a simple and easy-to-use UI component for a new interface introduced in Apple Maps, Shortcuts and Stocks app.

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -78,13 +78,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         panGesture.delegate = self
     }
 
-    func layoutViews(in vc: UIViewController) {
-        unowned let view = vc.view!
+    func layoutViews(in vc: UIViewController, container: UIView) {
+        container.insertSubview(backdropView, belowSubview: surfaceView)
+        backdropView.frame = container.bounds
 
-        view.insertSubview(backdropView, belowSubview: surfaceView)
-        backdropView.frame = view.bounds
-
-        layoutAdapter.prepareLayout(toParent: vc)
+        layoutAdapter.prepareLayout(toParent: vc, containerView: container)
     }
 
     func move(to: FloatingPanelPosition, animated: Bool, completion: (() -> Void)? = nil) {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -113,7 +113,7 @@ class FloatingPanelLayoutAdapter {
     private var halfConstraints: [NSLayoutConstraint] = []
     private var tipConstraints: [NSLayoutConstraint] = []
     private var offConstraints: [NSLayoutConstraint] = []
-    private var heightConstraints: [NSLayoutConstraint] = []
+    private var heightConstraint: NSLayoutConstraint? = nil
 
     private var fullInset: CGFloat {
         return layout.insetFor(position: .full) ?? 0.0
@@ -183,8 +183,8 @@ class FloatingPanelLayoutAdapter {
 
         // Fixed constraints of surface and backdrop views
         let surfaceConstraints = layout.prepareLayout(surfaceView: surfaceView, in: parent.view!)
-        let backdroptConstraints = [
             backdropView.topAnchor.constraint(equalTo: parent.view.topAnchor,
+        let backdropConstraints = [
                                               constant: 0.0),
             backdropView.leftAnchor.constraint(equalTo: parent.view.leftAnchor,
                                                constant: 0.0),
@@ -193,7 +193,7 @@ class FloatingPanelLayoutAdapter {
             backdropView.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor,
                                                  constant: 0.0),
             ]
-        fixedConstraints = surfaceConstraints + backdroptConstraints
+        fixedConstraints = surfaceConstraints + backdropConstraints
 
         // Flexible surface constarints for full, half, tip and off
         fullConstraints = [
@@ -222,13 +222,18 @@ class FloatingPanelLayoutAdapter {
             }
         }
 
-        NSLayoutConstraint.deactivate(heightConstraints)
         let height = self.parent.view.bounds.height - (safeAreaInsets.top + fullInset)
         heightConstraints = [
             surfaceView.heightAnchor.constraint(equalToConstant: height)
         ]
-        NSLayoutConstraint.activate(heightConstraints)
         surfaceView.set(bottomOverflow: heightBuffer)
+        if let constraint = self.heightConstraint {
+            NSLayoutConstraint.deactivate([constraint])
+        }
+        let constraint = surfaceView.heightAnchor.constraint(equalToConstant: height)
+
+        NSLayoutConstraint.activate([constraint])
+        heightConstraint = constraint
     }
 
     func activateLayout(of state: FloatingPanelPosition?) {

--- a/Framework/Sources/UIExtensions.swift
+++ b/Framework/Sources/UIExtensions.swift
@@ -41,6 +41,23 @@ extension UIViewController {
         }
     }
 }
+extension UIView {
+    var layoutInsets: UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            return safeAreaInsets
+        } else {
+            fatalError()
+        }
+    }
+    var layoutGuide: LayoutGuideProvider {
+        if #available(iOS 11.0, *) {
+            return safeAreaLayoutGuide
+        } else {
+            return CustomLayoutGuide(topAnchor: bottomAnchor,
+                                     bottomAnchor: topAnchor)
+        }
+    }
+}
 
 protocol SideLayoutGuideProvider {
     var leftAnchor: NSLayoutXAxisAnchor { get }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The new interface displays the related contents and utilities in parallel as a u
 - [x] Fluid animation and gesture handling
 - [x] Scroll view tracking
 - [x] Common UI elements: Grabber handle, Backdrop and Surface rounding corners
-- [x] 2 or 3 anchor positions(full, half, tip)
+- [x] 1~3 anchor positions(full, half, tip)
 - [x] Layout customization for all trait environments(i.e. Landscape orientation support)
 - [x] Behavior customization
 - [x] Free from common issues of Auto Layout and gesture handling
@@ -99,7 +99,7 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 
         // Set a content view controller.
         let contentVC = ContentViewController()
-        fpc.show(contentVC, sender: nil)
+        fpc.set(contentViewController: contentVC)
 
         // Track a scroll view(or the siblings) in the content view controller.
         fpc.track(scrollView: contentVC.tableView)
@@ -223,7 +223,7 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
         self.searchPanelVC = FloatingPanelController()
 
         let searchVC = SearchViewController()
-        self.searchPanelVC.show(searchVC, sender: nil)
+        self.searchPanelVC.set(contentViewController: searchVC)
         self.searchPanelVC.track(scrollView: contentVC.tableView)
 
         self.searchPanelVC.addPanel(toParent: self)
@@ -232,7 +232,7 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
         self.detailPanelVC = FloatingPanelController()
 
         let contentVC = ContentViewController()
-        self.detailPanelVC.show(contentVC, sender: nil)
+        self.detailPanelVC.set(contentViewController: contentVC)
         self.detailPanelVC.track(scrollView: contentVC.scrollView)
 
         self.detailPanelVC.addPanel(toParent: self)


### PR DESCRIPTION
Allow panel to be added to a subview of the view controller instead of the root view of the vc.

I added an optional `containerView` parameter to the `addPanel` func. If set, the panel is added to that containerView instead of `viewController.view`.

The sample app was updated to showcase the feature, using a containerView that is placed above a toolBar.

This requires iOS 11+ because safeAreaInsets aren't available on the view level in older iOS versions.