### PR TITLE
Improve delegate

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -33,7 +33,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     unowned let viewcontroller: FloatingPanelController
 
-    private(set) var state: FloatingPanelPosition = .tip
+    private(set) var state: FloatingPanelPosition = .tip {
+        didSet { viewcontroller.delegate?.floatingPanelDidChangePosition(viewcontroller) }
+    }
+
     private var isBottomState: Bool {
         let remains = layoutAdapter.layout.supportedPositions.filter { $0.rawValue > state.rawValue }
         return remains.count == 0

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -326,8 +326,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         // For _UISwipeActionPanGestureRecognizer
         if let scrollGestureRecognizers = scrollView.gestureRecognizers {
             for gesture in scrollGestureRecognizers {
-                if gesture !=  scrollView.panGestureRecognizer,
-                    gesture.state == .began || gesture.state == .changed {
+                guard gesture.state == .began || gesture.state == .changed
+                else { continue }
+
+                if gesture !=  scrollView.panGestureRecognizer {
                     return true
                 }
             }

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -12,6 +12,8 @@ public protocol FloatingPanelControllerDelegate: class {
     // if it returns nil, FloatingPanelController uses the default behavior
     func floatingPanel(_ vc: FloatingPanelController, behaviorFor newCollection: UITraitCollection) -> FloatingPanelBehavior?
 
+    func floatingPanelDidChangePosition(_ vc: FloatingPanelController) // changed the settled position in the model layer
+
     func floatingPanelDidMove(_ vc: FloatingPanelController) // any offset changes
 
     // called on start of dragging (may require some time and or distance to move)
@@ -34,6 +36,7 @@ public extension FloatingPanelControllerDelegate {
     func floatingPanel(_ vc: FloatingPanelController, behaviorFor newCollection: UITraitCollection) -> FloatingPanelBehavior? {
         return nil
     }
+    func floatingPanelDidChangePosition(_ vc: FloatingPanelController) {}
     func floatingPanelDidMove(_ vc: FloatingPanelController) {}
     func floatingPanelWillBeginDragging(_ vc: FloatingPanelController) {}
     func floatingPanelDidEndDragging(_ vc: FloatingPanelController, withVelocity velocity: CGPoint, targetPosition: FloatingPanelPosition) {}


### PR DESCRIPTION
Add these delegate methods
* `func floatingPanelDidChangePosition(_ vc: FloatingPanelController) `
* ~`func floatingPanel(_ vc: FloatingPanelController, shouldMoveBy: UIPanGestureRecognizer) -> Bool`~ This could be replaced with `FloatingPanelController.panGestureRecognizer.isEnable = false` or untracking a scroll view temporarily

Fix #46 