### PR TITLE
FloatingPanelController as a Modality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: swift
 branches:
   only:
     - master
+    - next
 cache:
   directories:
   - build

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -130,8 +130,8 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
 
         switch menu {
         case .showDetail:
-            detailPanelVC?.removeFromParent()
-
+            detailPanelVC?.removePanelFromParent(animated: false)
+            
             // Initialize FloatingPanelController
             detailPanelVC = FloatingPanelController()
 

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -17,6 +17,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
         case trackingTextView
         case showDetail
         case showModal
+        case showFloatingPanelModal
         case showTabBar
         case showNestedScrollView
         case showRemovablePanel
@@ -28,6 +29,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             case .trackingTextView: return "Scroll tracking(TextView)"
             case .showDetail: return "Show Detail Panel"
             case .showModal: return "Show Modal"
+            case .showFloatingPanelModal: return "Show Floating Panel Modal"
             case .showTabBar: return "Show Tab Bar"
             case .showNestedScrollView: return "Show Nested ScrollView"
             case .showRemovablePanel: return "Show Removable Panel"
@@ -41,6 +43,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
             case .trackingTextView: return "ConsoleViewController"
             case .showDetail: return "DetailViewController"
             case .showModal: return "ModalViewController"
+            case .showFloatingPanelModal: return nil
             case .showTabBar: return "TabBarViewController"
             case .showNestedScrollView: return "NestedScrollViewController"
             case .showRemovablePanel: return "DetailViewController"
@@ -144,6 +147,18 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
         case .showModal, .showTabBar:
             let modalVC = contentVC
             present(modalVC, animated: true, completion: nil)
+        case .showFloatingPanelModal:
+            let fpc = FloatingPanelController()
+            let contentVC = self.storyboard!.instantiateViewController(withIdentifier: "DetailViewController")
+            fpc.set(contentViewController: contentVC)
+            fpc.delegate = self
+
+            fpc.surfaceView.cornerRadius = 38.5
+            fpc.surfaceView.shadowHidden = false
+
+            fpc.isRemovalInteractionEnabled = true
+
+            self.present(fpc, animated: true, completion: nil)
         default:
             detailPanelVC?.removePanelFromParent(animated: true, completion: nil)
             mainPanelVC?.removePanelFromParent(animated: true) {
@@ -153,12 +168,18 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
     }
 
     func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
-        if currentMenu == .showRemovablePanel {
+        switch currentMenu {
+        case .showRemovablePanel:
             return newCollection.verticalSizeClass == .compact ? RemovablePanelLandscapeLayout() :  RemovablePanelLayout()
-        } else if case .showIntrinsicView = currentMenu {
+        case .showIntrinsicView:
             return IntrinsicPanelLayout(mainPanelVC.contentViewController)
-        } else {
-            return self
+        case .showFloatingPanelModal:
+            if vc != mainPanelVC && vc != detailPanelVC {
+                return ModalPanelLayout()
+            }
+            fallthrough
+        default:
+            return (newCollection.verticalSizeClass == .compact) ? nil  : self
         }
     }
 
@@ -223,6 +244,28 @@ class RemovablePanelLayout: FloatingPanelLayout {
 }
 
 class RemovablePanelLandscapeLayout: FloatingPanelLayout {
+    var initialPosition: FloatingPanelPosition {
+        return .half
+    }
+    var supportedPositions: Set<FloatingPanelPosition> {
+        return [.half]
+    }
+    var bottomInteractionBuffer: CGFloat {
+        return 261.0 - 22.0
+    }
+
+    func insetFor(position: FloatingPanelPosition) -> CGFloat? {
+        switch position {
+        case .half: return 261.0
+        default: return nil
+        }
+    }
+    func backdropAlphaFor(position: FloatingPanelPosition) -> CGFloat {
+        return 0.3
+    }
+}
+
+class ModalPanelLayout: FloatingPanelLayout {
     var initialPosition: FloatingPanelPosition {
         return .half
     }

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -278,9 +278,8 @@ class DebugTextViewController: UIViewController, UITextViewDelegate {
     }
 
     @IBAction func close(sender: UIButton) {
-        // Now impossible
-        // dismiss(animated: true, completion: nil)
-        (self.parent as? FloatingPanelController)?.removePanelFromParent(animated: true, completion: nil)
+        // (self.parent as? FloatingPanelController)?.removePanelFromParent(animated: true, completion: nil)
+        dismiss(animated: true, completion: nil)
     }
 }
 
@@ -452,9 +451,8 @@ class DebugTableViewController: UIViewController, UITableViewDataSource, UITable
 class DetailViewController: UIViewController {
     @IBOutlet weak var closeButton: UIButton!
     @IBAction func close(sender: UIButton) {
-        // Now impossible
-        // dismiss(animated: true, completion: nil)
-        (self.parent as? FloatingPanelController)?.removePanelFromParent(animated: true, completion: nil)
+        // (self.parent as? FloatingPanelController)?.removePanelFromParent(animated: true, completion: nil)
+        dismiss(animated: true, completion: nil)
     }
 
     @IBAction func buttonPressed(_ sender: UIButton) {

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -192,6 +192,7 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
         case .full: return UIScreen.main.bounds.height == 667.0 ? 18.0 : 16.0
         case .half: return 262.0
         case .tip: return 69.0
+        case .hidden: return nil
         }
     }
 }
@@ -591,6 +592,7 @@ class ModalSecondLayout: FloatingPanelLayout {
         case .full: return 18.0
         case .half: return 262.0
         case .tip: return 44.0
+        case .hidden: return nil
         }
     }
 }

--- a/Examples/Stocks/Stocks/ViewController.swift
+++ b/Examples/Stocks/Stocks/ViewController.swift
@@ -114,6 +114,7 @@ class FloatingPanelStocksLayout: FloatingPanelLayout {
         case .full: return 56.0
         case .half: return 262.0
         case .tip: return 85.0 + 44.0 // Visible + ToolView
+        default: return nil
         }
     }
 

--- a/Framework/FloatingPanel.xcodeproj/project.pbxproj
+++ b/Framework/FloatingPanel.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		54352E9821A521CA00CBCA08 /* FloatingPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54352E9721A521CA00CBCA08 /* FloatingPanelView.swift */; };
+		54352E9621A51A2500CBCA08 /* FloatingPanelTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54352E9521A51A2500CBCA08 /* FloatingPanelTransitioning.swift */; };
 		5450EEE421646DF500135936 /* FloatingPanelBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5450EEE321646DF500135936 /* FloatingPanelBehavior.swift */; };
 		545DB9CB2151169500CA77B8 /* FloatingPanel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 545DB9C12151169500CA77B8 /* FloatingPanel.framework */; };
 		545DB9D02151169500CA77B8 /* ViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545DB9CF2151169500CA77B8 /* ViewTests.swift */; };
@@ -34,6 +35,7 @@
 
 /* Begin PBXFileReference section */
 		54352E9721A521CA00CBCA08 /* FloatingPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelView.swift; sourceTree = "<group>"; };
+		54352E9521A51A2500CBCA08 /* FloatingPanelTransitioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelTransitioning.swift; sourceTree = "<group>"; };
 		5450EEE321646DF500135936 /* FloatingPanelBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelBehavior.swift; sourceTree = "<group>"; };
 		545DB9C12151169500CA77B8 /* FloatingPanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FloatingPanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		545DB9C42151169500CA77B8 /* FloatingPanelController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FloatingPanelController.h; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 				545DB9C52151169500CA77B8 /* Info.plist */,
 				545DB9C42151169500CA77B8 /* FloatingPanelController.h */,
 				545DB9DF21511AC100CA77B8 /* FloatingPanelController.swift */,
+				54352E9521A51A2500CBCA08 /* FloatingPanelTransitioning.swift */,
 				54CFBFC4215CD09C006B5735 /* FloatingPanel.swift */,
 				54CFBFC2215CD045006B5735 /* FloatingPanelLayout.swift */,
 				5450EEE321646DF500135936 /* FloatingPanelBehavior.swift */,
@@ -234,6 +237,7 @@
 				545DB9E021511AC100CA77B8 /* FloatingPanelController.swift in Sources */,
 				5450EEE421646DF500135936 /* FloatingPanelBehavior.swift in Sources */,
 				545DBA2B2152383100CA77B8 /* GrabberHandleView.swift in Sources */,
+				54352E9621A51A2500CBCA08 /* FloatingPanelTransitioning.swift in Sources */,
 				545DB9DE215118C800CA77B8 /* UIExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Framework/FloatingPanel.xcodeproj/project.pbxproj
+++ b/Framework/FloatingPanel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		54352E9821A521CA00CBCA08 /* FloatingPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54352E9721A521CA00CBCA08 /* FloatingPanelView.swift */; };
 		5450EEE421646DF500135936 /* FloatingPanelBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5450EEE321646DF500135936 /* FloatingPanelBehavior.swift */; };
 		545DB9CB2151169500CA77B8 /* FloatingPanel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 545DB9C12151169500CA77B8 /* FloatingPanel.framework */; };
 		545DB9D02151169500CA77B8 /* ViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545DB9CF2151169500CA77B8 /* ViewTests.swift */; };
@@ -32,6 +33,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		54352E9721A521CA00CBCA08 /* FloatingPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelView.swift; sourceTree = "<group>"; };
 		5450EEE321646DF500135936 /* FloatingPanelBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelBehavior.swift; sourceTree = "<group>"; };
 		545DB9C12151169500CA77B8 /* FloatingPanel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FloatingPanel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		545DB9C42151169500CA77B8 /* FloatingPanelController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FloatingPanelController.h; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				54CFBFC4215CD09C006B5735 /* FloatingPanel.swift */,
 				54CFBFC2215CD045006B5735 /* FloatingPanelLayout.swift */,
 				5450EEE321646DF500135936 /* FloatingPanelBehavior.swift */,
+				54352E9721A521CA00CBCA08 /* FloatingPanelView.swift */,
 				54CDC5D2215B6D5A007D205C /* FloatingPanelSurfaceView.swift */,
 				54CDC5D4215B6D8D007D205C /* FloatingPanelBackdropView.swift */,
 				545DBA2A2152383100CA77B8 /* GrabberHandleView.swift */,
@@ -225,6 +228,7 @@
 				54CDC5D3215B6D5A007D205C /* FloatingPanelSurfaceView.swift in Sources */,
 				54CFBFC3215CD045006B5735 /* FloatingPanelLayout.swift in Sources */,
 				54CDC5D5215B6D8D007D205C /* FloatingPanelBackdropView.swift in Sources */,
+				54352E9821A521CA00CBCA08 /* FloatingPanelView.swift in Sources */,
 				54CFBFC5215CD09C006B5735 /* FloatingPanel.swift in Sources */,
 				54ABD7AF216CCFF7002E6C13 /* Logger.swift in Sources */,
 				545DB9E021511AC100CA77B8 /* FloatingPanelController.swift in Sources */,

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -91,8 +91,25 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     func setUpViews(in vc: UIViewController) {
         unowned let view = vc.view!
 
-        view.addSubview(surfaceView)
-        view.insertSubview(backdropView, belowSubview: surfaceView)
+        // FloatingPanelSurfaceWrapperView is needed to update the surface's height
+        // without animation and prevent the backdrop's cut-off on orientation change.
+        let surfaceWrapperView = FloatingPanelSurfaceWrapperView()
+        surfaceWrapperView.frame = view.bounds
+        surfaceWrapperView.backgroundColor = .clear
+
+        view.addSubview(surfaceWrapperView)
+
+        surfaceWrapperView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            surfaceWrapperView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0.0),
+            surfaceWrapperView.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 0.0),
+            surfaceWrapperView.rightAnchor.constraint(equalTo: view.rightAnchor, constant: 0.0),
+            surfaceWrapperView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0.0),
+            ])
+
+        surfaceWrapperView.addSubview(surfaceView)
+
+        view.insertSubview(backdropView, belowSubview: surfaceWrapperView)
         backdropView.frame = view.bounds
     }
 

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -60,7 +60,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     init(_ vc: FloatingPanelController, layout: FloatingPanelLayout, behavior: FloatingPanelBehavior) {
         viewcontroller = vc
-        surfaceView = vc.view as! FloatingPanelSurfaceView
+
+        surfaceView = FloatingPanelSurfaceView()
+        surfaceView.backgroundColor = .white
+
         backdropView = FloatingPanelBackdropView()
         backdropView.backgroundColor = .black
         backdropView.alpha = 0.0
@@ -88,10 +91,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     func setUpViews(in vc: UIViewController) {
         unowned let view = vc.view!
 
+        view.addSubview(surfaceView)
         view.insertSubview(backdropView, belowSubview: surfaceView)
         backdropView.frame = view.bounds
-
-        layoutAdapter.prepareLayout(toParent: vc)
     }
 
     func move(to: FloatingPanelPosition, animated: Bool, completion: (() -> Void)? = nil) {

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -443,8 +443,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         let vth = behavior.removalVelocity
         let pth = max(min(behavior.removalProgress, 1.0), 0.0)
 
-        guard (safeAreaBottomY - posY) != 0 else { return false }
-        guard (currentY - posY) / (safeAreaBottomY - posY) >= pth || velocityVector.dy == vth else { return false }
+        let num = (currentY - posY)
+        let den = (safeAreaBottomY - posY)
+
+        guard num >= 0, den != 0, (num / den >= pth || velocityVector.dy == vth)
+        else { return false }
 
         return true
     }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -38,7 +38,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private var isBottomState: Bool {
-        let remains = layoutAdapter.layout.supportedPositions.filter { $0.rawValue > state.rawValue }
+        let remains = layoutAdapter.supportedPositions.filter { $0.rawValue > state.rawValue }
         return remains.count == 0
     }
 
@@ -113,17 +113,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     func move(to: FloatingPanelPosition, animated: Bool, completion: (() -> Void)? = nil) {
         move(from: state, to: to, animated: animated, completion: completion)
-    }
-
-    func present(animated: Bool, completion: (() -> Void)? = nil) {
-        if animated {
-            self.layoutAdapter.activateLayout(of: .hidden)
-        }
-        move(from: .hidden, to: layoutAdapter.layout.initialPosition, animated: animated, completion: completion)
-    }
-
-    func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
-        move(from: state, to: .hidden, animated: animated, completion: completion)
     }
 
     private func move(from: FloatingPanelPosition, to: FloatingPanelPosition, animated: Bool, completion: (() -> Void)? = nil) {
@@ -574,7 +563,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     private func directionalPosition(with translation: CGPoint) -> FloatingPanelPosition {
         let currentY = getCurrentY(from: initialFrame, with: translation)
 
-        let supportedPositions: Set = layoutAdapter.layout.supportedPositions
+        let supportedPositions = layoutAdapter.supportedPositions
 
         if supportedPositions.count == 1 {
             return state
@@ -609,7 +598,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     private func redirectionalPosition(with translation: CGPoint) -> FloatingPanelPosition {
         let currentY = getCurrentY(from: initialFrame, with: translation)
 
-        let supportedPositions: Set = layoutAdapter.layout.supportedPositions
+        let supportedPositions = layoutAdapter.supportedPositions
 
         if supportedPositions.count == 1 {
             return state
@@ -644,7 +633,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     private func targetPosition(with translation: CGPoint, velocity: CGPoint) -> (FloatingPanelPosition) {
         let currentY = getCurrentY(from: initialFrame, with: translation)
-        let supportedPositions: Set = layoutAdapter.layout.supportedPositions
+        let supportedPositions = layoutAdapter.supportedPositions
 
         if supportedPositions.count == 1 {
             return state

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -126,6 +126,7 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
 
     private var floatingPanel: FloatingPanel!
     private var layoutInsetsObservations: [NSKeyValueObservation] = []
+    private let modalTransition = FloatingPanelModalTransition()
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -141,7 +142,8 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     private func setUp() {
         _ = FloatingPanelController.dismissSwizzling
 
-        modalPresentationStyle = .overCurrentContext
+        modalPresentationStyle = .custom
+        transitioningDelegate = modalTransition
 
         floatingPanel = FloatingPanel(self,
                                       layout: fetchLayout(for: self.traitCollection),

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -282,19 +282,13 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
         precondition((parent is UITableViewController) == false, "UITableViewController should not be the parent because the view is a table view so that a floating panel doens't work well")
         precondition((parent is UICollectionViewController) == false, "UICollectionViewController should not be the parent because the view is a collection view so that a floating panel doens't work well")
 
-        view.frame = parent.view.bounds
         if let belowView = belowView {
             parent.view.insertSubview(self.view, belowSubview: belowView)
         } else {
             parent.view.addSubview(self.view)
         }
-        self.view.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            self.view.topAnchor.constraint(equalTo: parent.view.topAnchor, constant: 0.0),
-            self.view.leftAnchor.constraint(equalTo: parent.view.leftAnchor, constant: 0.0),
-            self.view.rightAnchor.constraint(equalTo: parent.view.rightAnchor, constant: 0.0),
-            self.view.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor, constant: 0.0),
-            ])
+
+        view.frame = parent.view.bounds // MUST
 
         parent.addChild(self)
 

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -51,6 +51,7 @@ public enum FloatingPanelPosition: Int, CaseIterable {
     case full
     case half
     case tip
+    case hidden
 }
 
 ///
@@ -414,6 +415,8 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
             return floatingPanel.layoutAdapter.middleY
         case .tip:
             return floatingPanel.layoutAdapter.bottomY
+        case .hidden:
+            return floatingPanel.layoutAdapter.hiddenY
         }
     }
 }

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -228,6 +228,7 @@ class FloatingPanelLayoutAdapter {
     // The method is separated from prepareLayout(to:) for the rotation support
     // It must be called in FloatingPanelController.traitCollectionDidChange(_:)
     func updateHeight() {
+        guard let vc = vc else { return }
         defer {
             UIView.performWithoutAnimation {
                 surfaceView.superview!.layoutIfNeeded()
@@ -239,7 +240,7 @@ class FloatingPanelLayoutAdapter {
         // of `vc` are relative values. For example, a view controller in
         // Navigation controller's safe area insets and frame can be changed whether
         // the navigation bar is translucent or not.
-        let height = self.vc.view.bounds.height - (safeAreaInsets.top + fullInset)
+        let height = vc.view.bounds.height - (safeAreaInsets.top + fullInset)
         heightConstraints = [
             surfaceView.heightAnchor.constraint(equalToConstant: height)
         ]

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -196,14 +196,10 @@ class FloatingPanelLayoutAdapter {
         // Fixed constraints of surface and backdrop views
         let surfaceConstraints = layout.prepareLayout(surfaceView: surfaceView, in: vc.view!)
         let backdropConstraints = [
-            backdropView.topAnchor.constraint(equalTo: vc.view.topAnchor,
-                                              constant: 0.0),
-            backdropView.leftAnchor.constraint(equalTo: vc.view.leftAnchor,
-                                               constant: 0.0),
-            backdropView.rightAnchor.constraint(equalTo: vc.view.rightAnchor,
-                                                constant: 0.0),
-            backdropView.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor,
-                                                 constant: 0.0),
+            backdropView.topAnchor.constraint(equalTo: vc.view.topAnchor, constant: 0.0),
+            backdropView.leftAnchor.constraint(equalTo: vc.view.leftAnchor,constant: 0.0),
+            backdropView.rightAnchor.constraint(equalTo: vc.view.rightAnchor, constant: 0.0),
+            backdropView.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor, constant: 0.0),
             ]
         fixedConstraints = surfaceConstraints + backdropConstraints
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -106,7 +106,7 @@ public class FloatingPanelDefaultLandscapeLayout: FloatingPanelLayout {
 
 
 class FloatingPanelLayoutAdapter {
-    private weak var parent: UIViewController!
+    private weak var vc: UIViewController!
     private weak var surfaceView: FloatingPanelSurfaceView!
     private weak var backdropView: FloatingPanelBackdropView!
 
@@ -119,7 +119,6 @@ class FloatingPanelLayoutAdapter {
         }
     }
 
-    private var parentHeight: CGFloat = 0.0
     private var heightBuffer: CGFloat = 88.0 // For bounce
     private var fixedConstraints: [NSLayoutConstraint] = []
     private var fullConstraints: [NSLayoutConstraint] = []
@@ -186,8 +185,8 @@ class FloatingPanelLayoutAdapter {
         self.backdropView = backdropView
     }
 
-    func prepareLayout(toParent parent: UIViewController) {
-        self.parent = parent
+    func prepareLayout(in vc: UIViewController) {
+        self.vc = vc
 
         surfaceView.translatesAutoresizingMaskIntoConstraints = false
         backdropView.translatesAutoresizingMaskIntoConstraints = false
@@ -195,34 +194,34 @@ class FloatingPanelLayoutAdapter {
         NSLayoutConstraint.deactivate(fixedConstraints + fullConstraints + halfConstraints + tipConstraints + offConstraints)
 
         // Fixed constraints of surface and backdrop views
-        let surfaceConstraints = layout.prepareLayout(surfaceView: surfaceView, in: parent.view!)
+        let surfaceConstraints = layout.prepareLayout(surfaceView: surfaceView, in: vc.view!)
         let backdropConstraints = [
-            backdropView.topAnchor.constraint(equalTo: parent.view.topAnchor,
+            backdropView.topAnchor.constraint(equalTo: vc.view.topAnchor,
                                               constant: 0.0),
-            backdropView.leftAnchor.constraint(equalTo: parent.view.leftAnchor,
+            backdropView.leftAnchor.constraint(equalTo: vc.view.leftAnchor,
                                                constant: 0.0),
-            backdropView.rightAnchor.constraint(equalTo: parent.view.rightAnchor,
+            backdropView.rightAnchor.constraint(equalTo: vc.view.rightAnchor,
                                                 constant: 0.0),
-            backdropView.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor,
+            backdropView.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor,
                                                  constant: 0.0),
             ]
         fixedConstraints = surfaceConstraints + backdropConstraints
 
         // Flexible surface constarints for full, half, tip and off
         fullConstraints = [
-            surfaceView.topAnchor.constraint(equalTo: parent.layoutGuide.topAnchor,
+            surfaceView.topAnchor.constraint(equalTo: vc.layoutGuide.topAnchor,
                                              constant: fullInset),
         ]
         halfConstraints = [
-            surfaceView.topAnchor.constraint(equalTo: parent.layoutGuide.bottomAnchor,
+            surfaceView.topAnchor.constraint(equalTo: vc.layoutGuide.bottomAnchor,
                                              constant: -halfInset),
         ]
         tipConstraints = [
-            surfaceView.topAnchor.constraint(equalTo: parent.layoutGuide.bottomAnchor,
+            surfaceView.topAnchor.constraint(equalTo: vc.layoutGuide.bottomAnchor,
                                              constant: -tipInset),
         ]
         offConstraints = [
-            surfaceView.topAnchor.constraint(equalTo: parent.view.bottomAnchor, constant: 0.0),
+            surfaceView.topAnchor.constraint(equalTo: vc.view.bottomAnchor, constant: 0.0),
         ]
     }
 
@@ -236,11 +235,11 @@ class FloatingPanelLayoutAdapter {
         }
 
         NSLayoutConstraint.deactivate(heightConstraints)
-        // Must use the parent height, not the screen height because safe area insets
-        // of the parent are relative values. For example, a view controller in
+        // Must use the`vc` height, not the screen height because safe area insets
+        // of `vc` are relative values. For example, a view controller in
         // Navigation controller's safe area insets and frame can be changed whether
         // the navigation bar is translucent or not.
-        let height = self.parent.view.bounds.height - (safeAreaInsets.top + fullInset)
+        let height = self.vc.view.bounds.height - (safeAreaInsets.top + fullInset)
         heightConstraints = [
             surfaceView.heightAnchor.constraint(equalToConstant: height)
         ]
@@ -305,8 +304,8 @@ class FloatingPanelLayoutAdapter {
             assert(halfInset > tipInset, "Invalid half and tip insets")
         }
         if fullInset > 0 {
-            assert(middleY > topY, "Invalid insets")
-            assert(bottomY > topY, "Invalid insets")
+            assert(middleY > topY, "Invalid insets { topY: \(topY), middleY: \(middleY) }")
+            assert(bottomY > topY, "Invalid insets { topY: \(topY), bottomY: \(bottomY) }")
         }
     }
 }

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -10,7 +10,10 @@ class FloatingPanelSurfaceContentView: UIView {}
 /// A view that presents a surface interface in a floating panel.
 public class FloatingPanelSurfaceView: UIView {
 
-    /// A GrabberHandleView object displayed at the top of the surface view
+    /// A GrabberHandleView object displayed at the top of the surface view.
+    ///
+    /// To use a custom grabber handle, hide this and then add the custom one
+    /// to the surface view at appropirate coordinates.
     public var grabberHandle: GrabberHandleView!
 
     /// The height of the grabber bar area

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -1,0 +1,92 @@
+//
+//  Created by Shin Yamamoto on 2018/11/21.
+//  Copyright © 2018 Shin Yamamoto. All rights reserved.
+//
+
+import UIKit
+
+class FloatingPanelModalTransition: NSObject, UIViewControllerTransitioningDelegate {
+    func animationController(forPresented presented: UIViewController,
+                             presenting: UIViewController,
+                             source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return FloatingPanelModalPresentTransition()
+    }
+
+    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return FloatingPanelModalDismissTransition()
+    }
+
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        return FloatingPanelPresentationController(presentedViewController: presented, presenting: presenting)
+    }
+}
+
+class FloatingPanelPresentationController: UIPresentationController {
+    override func presentationTransitionWillBegin() {
+        guard
+            let containerView = self.containerView,
+            let fpc = presentedViewController as? FloatingPanelController,
+            let toView = fpc.view
+        else { fatalError() }
+
+        fpc.view.frame = containerView.bounds
+
+        containerView.addSubview(toView)
+        toView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            toView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 0.0),
+            toView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0.0),
+            toView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0.0),
+            toView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0.0),
+            ])
+    }
+    override func presentationTransitionDidEnd(_ completed: Bool) {
+        if let fpc = presentedViewController as? FloatingPanelController{
+            // For non-animated presentation
+            fpc.show(animated: false)
+        }
+    }
+}
+
+class FloatingPanelModalPresentTransition: NSObject, UIViewControllerAnimatedTransitioning {
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        guard
+            let toVC = transitionContext?.viewController(forKey: .to) as? FloatingPanelController
+        else { fatalError()}
+
+        let animator = toVC.behavior.addAnimator(toVC, to: toVC.layout.initialPosition)
+        return TimeInterval(animator.duration)
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard
+            let toVC = transitionContext.viewController(forKey: .to) as? FloatingPanelController
+        else { fatalError() }
+
+        toVC.show(animated: true) {
+            transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+        }
+    }
+}
+
+class FloatingPanelModalDismissTransition: NSObject, UIViewControllerAnimatedTransitioning {
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        guard
+            let fromVC = transitionContext?.viewController(forKey: .from) as? FloatingPanelController
+        else { fatalError()}
+
+        let animator = fromVC.behavior.removeAnimator(fromVC, from: fromVC.position)
+        return TimeInterval(animator.duration)
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard
+            let fromVC = transitionContext.viewController(forKey: .from) as? FloatingPanelController
+        else { fatalError() }
+
+        fromVC.hide(animated: true) {
+            transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+        }
+    }
+}
+

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -43,6 +43,9 @@ class FloatingPanelPresentationController: UIPresentationController {
             let fpView = fpc.view
             else { fatalError() }
 
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
+        fpc.backdropView.addGestureRecognizer(tapGesture)
+
         containerView.addSubview(fpView)
         fpView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -51,6 +54,10 @@ class FloatingPanelPresentationController: UIPresentationController {
             fpView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0.0),
             fpView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0.0),
             ])
+    }
+
+    @objc func handleBackdrop(tapGesture: UITapGestureRecognizer) {
+        presentedViewController.dismiss(animated: true, completion: nil)
     }
 }
 

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -43,7 +43,14 @@ class FloatingPanelPresentationController: UIPresentationController {
     override func presentationTransitionDidEnd(_ completed: Bool) {
         if let fpc = presentedViewController as? FloatingPanelController{
             // For non-animated presentation
-            fpc.show(animated: false)
+            fpc.show(animated: false, completion: nil)
+        }
+    }
+
+    override func dismissalTransitionDidEnd(_ completed: Bool) {
+        if let fpc = presentedViewController as? FloatingPanelController{
+            // For non-animated presentation
+            fpc.hide(animated: false, completion: nil)
         }
     }
 }

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -47,13 +47,7 @@ class FloatingPanelPresentationController: UIPresentationController {
         fpc.backdropView.addGestureRecognizer(tapGesture)
 
         containerView.addSubview(fpView)
-        fpView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            fpView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 0.0),
-            fpView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0.0),
-            fpView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0.0),
-            fpView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0.0),
-            ])
+        fpView.frame = containerView.bounds //MUST
     }
 
     @objc func handleBackdrop(tapGesture: UITapGestureRecognizer) {

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -22,55 +22,54 @@ class FloatingPanelModalTransition: NSObject, UIViewControllerTransitioningDeleg
 }
 
 class FloatingPanelPresentationController: UIPresentationController {
-    override func presentationTransitionWillBegin() {
-        guard
-            let containerView = self.containerView,
-            let fpc = presentedViewController as? FloatingPanelController,
-            let toView = fpc.view
-        else { fatalError() }
-
-        fpc.view.frame = containerView.bounds
-
-        containerView.addSubview(toView)
-        toView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            toView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 0.0),
-            toView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0.0),
-            toView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0.0),
-            toView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0.0),
-            ])
-    }
     override func presentationTransitionDidEnd(_ completed: Bool) {
-        if let fpc = presentedViewController as? FloatingPanelController{
-            // For non-animated presentation
+        // For non-animated presentation
+        if let fpc = presentedViewController as? FloatingPanelController, fpc.position == .hidden {
             fpc.show(animated: false, completion: nil)
         }
     }
 
     override func dismissalTransitionDidEnd(_ completed: Bool) {
-        if let fpc = presentedViewController as? FloatingPanelController{
-            // For non-animated presentation
+        // For non-animated dismissal
+        if let fpc = presentedViewController as? FloatingPanelController, fpc.position != .hidden {
             fpc.hide(animated: false, completion: nil)
         }
+    }
+
+    override func containerViewWillLayoutSubviews() {
+        guard
+            let containerView = self.containerView,
+            let fpc = presentedViewController as? FloatingPanelController,
+            let fpView = fpc.view
+            else { fatalError() }
+
+        containerView.addSubview(fpView)
+        fpView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            fpView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 0.0),
+            fpView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0.0),
+            fpView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0.0),
+            fpView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0.0),
+            ])
     }
 }
 
 class FloatingPanelModalPresentTransition: NSObject, UIViewControllerAnimatedTransitioning {
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         guard
-            let toVC = transitionContext?.viewController(forKey: .to) as? FloatingPanelController
+            let fpc = transitionContext?.viewController(forKey: .to) as? FloatingPanelController
         else { fatalError()}
 
-        let animator = toVC.behavior.addAnimator(toVC, to: toVC.layout.initialPosition)
+        let animator = fpc.behavior.addAnimator(fpc, to: fpc.layout.initialPosition)
         return TimeInterval(animator.duration)
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         guard
-            let toVC = transitionContext.viewController(forKey: .to) as? FloatingPanelController
+            let fpc = transitionContext.viewController(forKey: .to) as? FloatingPanelController
         else { fatalError() }
 
-        toVC.show(animated: true) {
+        fpc.show(animated: true) {
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }
     }
@@ -79,19 +78,19 @@ class FloatingPanelModalPresentTransition: NSObject, UIViewControllerAnimatedTra
 class FloatingPanelModalDismissTransition: NSObject, UIViewControllerAnimatedTransitioning {
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         guard
-            let fromVC = transitionContext?.viewController(forKey: .from) as? FloatingPanelController
+            let fpc = transitionContext?.viewController(forKey: .from) as? FloatingPanelController
         else { fatalError()}
 
-        let animator = fromVC.behavior.removeAnimator(fromVC, from: fromVC.position)
+        let animator = fpc.behavior.removeAnimator(fpc, from: fpc.position)
         return TimeInterval(animator.duration)
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         guard
-            let fromVC = transitionContext.viewController(forKey: .from) as? FloatingPanelController
+            let fpc = transitionContext.viewController(forKey: .from) as? FloatingPanelController
         else { fatalError() }
 
-        fromVC.hide(animated: true) {
+        fpc.hide(animated: true) {
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }
     }

--- a/Framework/Sources/FloatingPanelView.swift
+++ b/Framework/Sources/FloatingPanelView.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Shin Yamamoto on 2018/11/21.
+//  Copyright © 2018 Shin Yamamoto. All rights reserved.
+//
+
+import UIKit
+
+class FloatingPanelPassThroughView: UIView {
+    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+        switch view {
+        case is FloatingPanelPassThroughView:
+            return nil
+        default:
+            return view
+        }
+    }
+}

--- a/Framework/Sources/FloatingPanelView.swift
+++ b/Framework/Sources/FloatingPanelView.swift
@@ -16,3 +16,15 @@ class FloatingPanelPassThroughView: UIView {
         }
     }
 }
+
+class FloatingPanelSurfaceWrapperView: UIView {
+    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+        switch view {
+        case is FloatingPanelSurfaceWrapperView:
+            return nil
+        default:
+            return view
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ The new interface displays the related contents and utilities in parallel as a u
   - [CocoaPods](#cocoapods)
   - [Carthage](#carthage)
 - [Getting Started](#getting-started)
+  - [Add a floating panel as a child view controller](#add-a-floating-panel-as-a-child-view-controller)
+  - [Present a floating panel as a modality](#present-a-floating-panel-as-a-modality)
 - [Usage](#usage)
+  - [Show/Hide a floating panel in a view with your view hierarchy](#showhide-a-floating-panel-in-a-view-with-your-view-hierarchy)
   - [Customize the layout with `FloatingPanelLayout` protocol](#customize-the-layout-with-floatingpanellayout-protocol)
     - [Change the initial position and height](#change-the-initial-position-and-height)
     - [Support your landscape layout](#support-your-landscape-layout)
@@ -52,6 +55,7 @@ The new interface displays the related contents and utilities in parallel as a u
 - [x] Layout customization for all trait environments(i.e. Landscape orientation support)
 - [x] Behavior customization
 - [x] Free from common issues of Auto Layout and gesture handling
+- [x] Modal presentation
 
 Examples are here.
 
@@ -84,6 +88,8 @@ github "scenee/FloatingPanel"
 
 ## Getting Started
 
+### Add a floating panel as a child view controller
+
 ```swift
 import UIKit
 import FloatingPanel
@@ -112,14 +118,60 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+
         // Remove the views managed by the `FloatingPanelController` object from self.view.
         fpc.removePanelFromParent()
     }
-    ...
 }
 ```
 
+### Present a floating panel as a modality
+
+```swift
+let fpc = FloatingPanelController()
+let contentVC = ...
+fpc.set(contentViewController: contentVC)
+
+fpc.isRemovalInteractionEnabled = true // Optional: Let it removable by a swipe-down
+
+self.present(fpc, animated: true, completion: nil)
+```
+
+You can show a floating panel over UINavigationController from the containnee view controllers like a Modal of overCurrentContext style.
+
+NOTE: FloatingPanelController has the custom presentation controller. If you would like to cutomize the presentation/dimissal, please see [FloatingPanelTransitioning](https://github.com/SCENEE/FloatingPanel/blob/feat-modality/Framework/Sources/FloatingPanelTransitioning.swift).
+
 ## Usage
+
+### Show/Hide a floating panel in a view with your view hierarchy
+
+```swift
+// Add the controller and the managed views to a view controller.
+// From the second time, just call `show(animated:completion)`.
+view.addSubview(fpc.view)
+fpc.view.frame = view.bounds // MUST
+parent.addChild(fpc)
+
+// Show a floating panel to the initial position defined in your `FloatingPanelLayout` object.
+fpc.show(animated: true) {
+
+    // Only for the first time
+    self.didMove(toParent: self)
+}
+
+...
+
+// Hide it
+fpc.hide(animated: true) {
+
+    // Remove it if needed
+    self.willMove(toParent: nil)
+    self.view.removeFromSuperview()
+    self.removeFromParent()
+}
+```
+
+NOTE: `FloatingPanelController` wraps `show`/`hide` with `addPanel`/`removePanelFromParent` for easy-to-use. But `show`/`hide` are more convenience for your app.
 
 ### Customize the layout with `FloatingPanelLayout` protocol
 
@@ -131,7 +183,6 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
     func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
         return MyFloatingPanelLayout()
     }
-    ...
 }
 
 class MyFloatingPanelLayout: FloatingPanelLayout {
@@ -144,6 +195,7 @@ class MyFloatingPanelLayout: FloatingPanelLayout {
             case .full: return 16.0 // A top inset from safe area
             case .half: return 216.0 // A bottom inset from the safe area
             case .tip: return 44.0 // A bottom inset from the safe area
+            default: return nil // Or `case .hidden: return nil`
         }
     }
 }
@@ -157,7 +209,6 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
     func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
         return (newCollection.verticalSizeClass == .compact) ? FloatingPanelLandscapeLayout() : nil // Returning nil indicates to use the default layout
     }
-    ...
 }
 
 class FloatingPanelLandscapeLayout: FloatingPanelLayout {
@@ -195,90 +246,67 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
     func floatingPanel(_ vc: FloatingPanelController, behaviorFor newCollection: UITraitCollection) -> FloatingPanelBehavior? {
         return FloatingPanelStocksBehavior()
     }
-    ...
 }
-...
 
 class FloatingPanelStocksBehavior: FloatingPanelBehavior {
-    var velocityThreshold: CGFloat {
-        return 15.0
-    }
-
+    ...
     func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
         let damping = self.damping(with: velocity)
         let springTiming = UISpringTimingParameters(dampingRatio: damping, initialVelocity: velocity)
         return UIViewPropertyAnimator(duration: 0.5, timingParameters: springTiming)
     }
-    ...
 }
 ```
 
 ### Use a custom grabber handle
 
 ```swift
-class ViewController: UIViewController {
-    ...
-    override func viewDidLoad() {
-        ...
-        let myGrabberHandleView = MyGrabberHandleView()
-        fpc.surfaceView.grabberHandle.isHidden = true
-        fpc.surfaceView.addSubview(myGrabberHandleView)
-    }
-    ...
-}
+let myGrabberHandleView = MyGrabberHandleView()
+fpc.surfaceView.grabberHandle.isHidden = true
+fpc.surfaceView.addSubview(myGrabberHandleView)
 ```
 
 ### Add tap gestures to the surface or backdrop views
 
 ```swift
-class ViewController: UIViewController, FloatingPanelControllerDelegate {
+override func viewDidLoad() {
     ...
-    override func viewDidLoad() {
-        ...
-        surfaceTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleSurface(tapGesture:)))
-        fpc.surfaceView.addGestureRecognizer(surfaceTapGesture)
+    surfaceTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleSurface(tapGesture:)))
+    fpc.surfaceView.addGestureRecognizer(surfaceTapGesture)
 
-        backdropTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
-        fpc.backdropView.addGestureRecognizer(backdropTapGesture)
+    backdropTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
+    fpc.backdropView.addGestureRecognizer(backdropTapGesture)
 
-        surfaceTapGesture.isEnabled = (fpc.position == .tip)
-        ...
-    }
-    ...
-    // Enable `surfaceTapGesture` only at `tip` position
-    func floatingPanelDidChangePosition(_ vc: FloatingPanelController) {
-        surfaceTapGesture.isEnabled = (vc.position == .tip)
-    }
+    surfaceTapGesture.isEnabled = (fpc.position == .tip)
+}
+
+// Enable `surfaceTapGesture` only at `tip` position
+func floatingPanelDidChangePosition(_ vc: FloatingPanelController) {
+    surfaceTapGesture.isEnabled = (vc.position == .tip)
 }
 ```
 
 ### Create an additional floating panel for a detail
 
 ```swift
-class ViewController: UIViewController, FloatingPanelControllerDelegate {
-    var searchPanelVC: FloatingPanelController!
-    var detailPanelVC: FloatingPanelController!
+override func viewDidLoad() {
+    // Setup Search panel
+    self.searchPanelVC = FloatingPanelController()
 
-    override func viewDidLoad() {
-        // Setup Search panel
-        self.searchPanelVC = FloatingPanelController()
+    let searchVC = SearchViewController()
+    self.searchPanelVC.set(contentViewController: searchVC)
+    self.searchPanelVC.track(scrollView: contentVC.tableView)
 
-        let searchVC = SearchViewController()
-        self.searchPanelVC.set(contentViewController: searchVC)
-        self.searchPanelVC.track(scrollView: contentVC.tableView)
+    self.searchPanelVC.addPanel(toParent: self)
 
-        self.searchPanelVC.addPanel(toParent: self)
+    // Setup Detail panel
+    self.detailPanelVC = FloatingPanelController()
 
-        // Setup Detail panel
-        self.detailPanelVC = FloatingPanelController()
+    let contentVC = ContentViewController()
+    self.detailPanelVC.set(contentViewController: contentVC)
+    self.detailPanelVC.track(scrollView: contentVC.scrollView)
 
-        let contentVC = ContentViewController()
-        self.detailPanelVC.set(contentViewController: contentVC)
-        self.detailPanelVC.track(scrollView: contentVC.scrollView)
-
-        self.detailPanelVC.addPanel(toParent: self)
-    }
-    ...
+    self.detailPanelVC.addPanel(toParent: self)
 }
 ```
 
@@ -287,15 +315,15 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 In the following example, I move a floating panel to full or half position while opening or closing a search bar like Apple Maps.
 
 ```swift
-    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        ...
-        fpc.move(to: .half, animated: true)
-    }
+func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+    ...
+    fpc.move(to: .half, animated: true)
+}
 
-    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
-        ...
-        fpc.move(to: .full, animated: true)
-    }
+func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+    ...
+    fpc.move(to: .full, animated: true)
+}
 ```
 
 ### Work your contents together with a floating panel behavior
@@ -315,7 +343,6 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
             searchVC.hideHeader()
         }
     }
-    ...
 }
 ```
 
@@ -323,7 +350,7 @@ class ViewController: UIViewController, FloatingPanelControllerDelegate {
 
 ### 'Show' or 'Show Detail' Segues from `FloatingPanelController`'s content view controller
 
-'Show' or 'Show Detail' segues from a content view controller will be managed by a view controller(hereinafter called 'master VC') adding a floating panel. Because a floating panel is just a subview of the master VC.
+'Show' or 'Show Detail' segues from a content view controller will be managed by a view controller(hereinafter called 'master VC') adding a floating panel. Because a floating panel is just a subview of the master VC(except for modality).
 
 `FloatingPanelController` has no way to manage a stack of view controllers like `UINavigationController`. If so, it would be so complicated and the interface will become `UINavigationController`. This component should not have the responsibility to manage the stack.
 
@@ -346,17 +373,16 @@ class ViewController: UIViewController {
 
         secondFpc.addPanel(toParent: self)
     }
-    ...
 }
 ```
 
-A `FloatingPanelController` object proxies an action for `show(_:sender)` to the master VC. That's why the master VC can handle a destination view controller of a 'Show' or 'Show Detail' segue and you can hook `show(_:sender)` to show a secondally floating panel set the destination view controller to the content.
+A `FloatingPanelController` object proxies an action for `show(_:sender)` to the master VC. That's why the master VC can handle a destination view controller of a 'Show' or 'Show Detail' segue and you can hook `show(_:sender)` to show a secondary floating panel set the destination view controller to the content.
 
 It's a great way to decouple between a floating panel and the content VC.
 
 ### FloatingPanelSurfaceView's issue on iOS 10
 
-* On iOS 10,   `FloatingPanelSurfaceView.cornerRadius` isn't not automatically masked with the top rounded corners  because of UIVisualEffectView issue. See https://forums.developer.apple.com/thread/50854. 
+* On iOS 10, `FloatingPanelSurfaceView.cornerRadius` isn't not automatically masked with the top rounded corners  because of `UIVisualEffectView` issue. See https://forums.developer.apple.com/thread/50854. 
 So you need to draw top rounding corners of your content.  Here is an example in Examples/Maps.
 ```swift
 override func viewDidLayoutSubviews() {
@@ -367,11 +393,11 @@ override func viewDidLayoutSubviews() {
     }
 }
 ```
-* If you sets clear color to `FloatingPanelSurfaceView.backgroundColor`, please note the bottom overflow of your content on bouncing at full position. To prevent it, you need to expand your content. For example, See Example/Maps's Auto Layout settings of UIVisualEffectView in Main.storyborad.
+* If you sets clear color to `FloatingPanelSurfaceView.backgroundColor`, please note the bottom overflow of your content on bouncing at full position. To prevent it, you need to expand your content. For example, See Example/Maps App's Auto Layout settings of `UIVisualEffectView` in Main.storyborad.
 
 ## Author
 
-Shin Yamamoto <shin@scenee.com>
+Shin Yamamoto <shin@scenee.com> | [@scenee](https://twitter.com/scenee)
 
 ## License
 


### PR DESCRIPTION
## Motivation
Now `FloatingPanelController`  can’t work independent without the parent VC because its views and layouts are coupled with the parent’s view.

If  it would be decoupled from the parent VC, a floating panel could be more portable and easy to arrange it in any view hierarchy. 

The change will let you allow to use FloatingPanelController like other native container VC like `UINavigationController`, `UITabBarViewController` etc. 

For example, you can present `FloatingPanelController` as a modality.

## Use cases 
### Present a floating panel as a Modality
``` swift
let fpc = FloatingPanelController()
self.present(fpc, animated: true)
```
### Add a floating panel to a container view.
```swift
let fpc = FloatingPanelController()
aContainerView.addSubview(fpc.view)
fpc.view.frame = aContainer.bounds // MUST
parent.addChild(fpc)
fpc.show(animated: true) { 
	self.didMove(toParent: self)
}
```
```swift
let fpc = FloatingPanelController()
fpc.hide(animated: true) {
        // If needed
	self.willMove(toParent: nil)
	self.view.removeFromSuperview()
	self.removeFromParent()
}
```

## New API
* `FloatingPanelController.show(animated:completion:)`
* `FloatingPanelController.hide(animated:completion:)`

## Backward compatibility
No break backward compatibility just because the above 2 new methods and the internal implementation is changed.

## Release target 
v1.3.0 or later

## Related features
- #50, #57: Intrinsic heigh(Fit to content) is much useful on the above use cases. The feature should be merged.

## TODO
- [x] Fix the backdrop broken on orientation change.
- [x] Fix that the presentation as a modality is delayed sometimes.