### PR TITLE
Fix bugs

### DIFF
--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -198,7 +198,13 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     }
 
     private func update(safeAreaInsets: UIEdgeInsets) {
+        // preserve the current content offset
+        let contentOffset = scrollView?.contentOffset
+
         floatingPanel.safeAreaInsets = safeAreaInsets
+
+        scrollView?.contentOffset = contentOffset ?? .zero
+
         switch contentInsetAdjustmentBehavior {
         case .always:
             scrollView?.contentInset = adjustedContentInsets


### PR DESCRIPTION
## Fix an invalid content offset on height change

a floating panel has the problem when it's displayed in a modality(i.e. "Show Tab Bar"/"Show Modal" in Samples app)

## Fix panning at grabber area

When a floating panel is moved in the grabber area, the tracking scroll view's content offset must not be reset to the top.