### PR TITLE
The default interaction animator should be uninterruptible

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -313,7 +313,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 return
             }
 
-            if let animator = self.animator {
+            if let animator = self.animator, animator.isInterruptible {
                 animator.stopAnimation(true)
                 self.animator = nil
             }
@@ -491,6 +491,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func startAnimation(to targetPosition: FloatingPanelPosition, at distance: CGFloat, with velocity: CGPoint) {
+        log.debug("startAnimation", targetPosition, distance, velocity)
         let targetY = layoutAdapter.positionY(for: targetPosition)
         let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: max(min(velocity.y/distance, 30.0), -30.0)) : .zero
         let animator = behavior.interactionAnimator(self.viewcontroller, to: targetPosition, with: velocityVector)

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -568,7 +568,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 }
                 return currentY > middleY ? .tip : .half
             case .half:
-                return translation.y >= 0 ? .tip : .full
+                return currentY > middleY ? .tip : .full
             case .tip:
                 if translation.y >= 0 {
                     return .tip

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -85,7 +85,9 @@ public extension FloatingPanelBehavior {
 class FloatingPanelDefaultBehavior: FloatingPanelBehavior {
     func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
         let timing = timeingCurve(with: velocity)
-        return UIViewPropertyAnimator(duration: 0, timingParameters: timing)
+        let animator = UIViewPropertyAnimator(duration: 0, timingParameters: timing)
+        animator.isInterruptible = false
+        return animator
     }
 
     private func timeingCurve(with velocity: CGVector) -> UITimingCurveProvider {


### PR DESCRIPTION
Because an interruptible animator causes a wobbling at the animation start.
when a user flick a panel quickly to move to full position nearby the position.