### PR TITLE
Fix failure requirements

### DIFF
--- a/Examples/Samples/Sources/Base.lproj/Main.storyboard
+++ b/Examples/Samples/Sources/Base.lproj/Main.storyboard
@@ -372,6 +372,7 @@
                     </view>
                     <size key="freeformSize" width="375" height="667"/>
                     <connections>
+                        <outlet property="nestedScrollView" destination="xba-kG-VQ2" id="ddV-kf-37A"/>
                         <outlet property="scrollView" destination="sBe-tN-uMi" id="h4S-Zl-cLO"/>
                     </connections>
                 </viewController>

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -198,6 +198,15 @@ class SampleListViewController: UIViewController, UITableViewDataSource, UITable
         }
     }
 
+    func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool {
+        switch currentMenu {
+        case .showNestedScrollView:
+            return (vc.contentViewController as? NestedScrollViewController)?.nestedScrollView.gestureRecognizers?.contains(gestureRecognizer) ?? false
+        default:
+            return false
+        }
+    }
+
     var initialPosition: FloatingPanelPosition {
         return .half
     }
@@ -265,6 +274,7 @@ class ModalPanelLayout: FloatingPanelIntrinsicLayout {
 
 class NestedScrollViewController: UIViewController {
     @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var nestedScrollView: UIScrollView!
 
     @IBAction func longPressed(_ sender: Any) {
         print("LongPressed!")

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -180,6 +180,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
         /* log.debug("shouldRecognizeSimultaneouslyWith", otherGestureRecognizer) */
 
+        if viewcontroller.delegate?.floatingPanel(viewcontroller, shouldRecognizeSimultaneouslyWith: otherGestureRecognizer) ?? false {
+            return true
+        }
+
         // all gestures of the tracking scroll view should be recognized in parallel
         // and handle them in self.handle(panGesture:)
         return scrollView?.gestureRecognizers?.contains(otherGestureRecognizer) ?? false
@@ -194,7 +198,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         guard gestureRecognizer == panGesture else { return false }
 
-        log.debug("shouldRequireFailureOf", otherGestureRecognizer)
+        /* log.debug("shouldRequireFailureOf", otherGestureRecognizer) */
 
         // Should begin the pan gesture without waiting for the tracking scroll view's gestures.
         // `scrollView.gestureRecognizers` can contains the following gestures
@@ -211,6 +215,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 return false
             }
         }
+
+        if viewcontroller.delegate?.floatingPanel(viewcontroller, shouldRecognizeSimultaneouslyWith: otherGestureRecognizer) ?? false {
+            return false
+        }
+
 
         switch otherGestureRecognizer {
         case is UIPanGestureRecognizer,

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -187,29 +187,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         guard gestureRecognizer == panGesture else { return false }
-
         /* log.debug("shouldBeRequiredToFailBy", otherGestureRecognizer) */
-
-        // The tracking scroll view's gestures should begin without waiting for the pan gesture failure.
-        // `scrollView.gestureRecognizers` can contains the following gestures
-        // * UIScrollViewDelayedTouchesBeganGestureRecognizer
-        // * UIScrollViewPanGestureRecognizer (scrollView.panGestureRecognizer)
-        // * _UIDragAutoScrollGestureRecognizer
-        // * _UISwipeActionPanGestureRecognizer
-        // * UISwipeDismissalGestureRecognizer
-        if let scrollView = scrollView,
-            let scrollGestureRecognizers = scrollView.gestureRecognizers,
-            scrollGestureRecognizers.contains(otherGestureRecognizer) {
-            return false
-        }
-
-        // Long press gesture should begin without waiting for the pan gesture failure.
-        if otherGestureRecognizer is UILongPressGestureRecognizer {
-            return false
-        }
-
-        // Do not begin any other gestures until the pan gesture fails.
-        return true
+        return false
     }
 
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -27,6 +27,8 @@ public protocol FloatingPanelControllerDelegate: class {
     func floatingPanelDidEndDraggingToRemove(_ vc: FloatingPanelController, withVelocity velocity: CGPoint)
     // called when its views are removed from a parent view controller
     func floatingPanelDidEndRemove(_ vc: FloatingPanelController)
+
+    func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool
 }
 
 public extension FloatingPanelControllerDelegate {
@@ -45,6 +47,8 @@ public extension FloatingPanelControllerDelegate {
 
     func floatingPanelDidEndDraggingToRemove(_ vc: FloatingPanelController, withVelocity velocity: CGPoint) {}
     func floatingPanelDidEndRemove(_ vc: FloatingPanelController) {}
+
+    func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool { return false }
 }
 
 public enum FloatingPanelPosition: Int, CaseIterable {


### PR DESCRIPTION
Fix #76, #88 

## Changes

- Any gestures don't wait for `FloatingPanelController.panGestureRecognizer`
- Add new delegate method to customize the failure requirements and simultaneousness of `FloatingPanelController.panGestureRecognizer`
```swift
public protocol FloatingPanelControllerDelegate: class {
    ...
    func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool
}
```