### PR TITLE
Fix the event handling on presentation modally

### DIFF
--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -59,6 +59,8 @@ class FloatingPanelPresentationController: UIPresentationController {
             fpView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0.0),
             ])
 
+        (fpView as? FloatingPanelPassThroughView)?.eventForwardingView = presentingViewController.view
+
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
         fpc.backdropView.addGestureRecognizer(tapGesture)
     }

--- a/Framework/Sources/FloatingPanelView.swift
+++ b/Framework/Sources/FloatingPanelView.swift
@@ -6,13 +6,14 @@
 import UIKit
 
 class FloatingPanelPassThroughView: UIView {
+    public weak var eventForwardingView: UIView?
     public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        let view = super.hitTest(point, with: event)
-        switch view {
-        case is FloatingPanelPassThroughView:
-            return nil
+        let hitView = super.hitTest(point, with: event)
+        switch hitView {
+        case self:
+            return eventForwardingView?.hitTest(self.convert(point, to: eventForwardingView), with: event)
         default:
-            return view
+            return hitView
         }
     }
 }


### PR DESCRIPTION
If an alpha of the controller's backdrop view is zero, the presentation controller
must not block any touch event outside of surface view.

Fix #99 