### PR TITLE
Fix a crash on tap dismissal with a second touch

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -360,6 +360,12 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     private func panningEnd(with translation: CGPoint, velocity: CGPoint) {
         log.debug("panningEnd")
+
+        guard state != .hidden else {
+            log.debug("Already hidden")
+            return
+        }
+
         if interactionInProgress == false {
             initialFrame = surfaceView.frame
         }


### PR DESCRIPTION
For example, a user tap the backdrop view to dismiss it while dragging
the surface view on presentation modally.

Fix #100