### PR TITLE
fix(delegateIgnored): Allow to set delegate on init

### DIFF
--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -70,7 +70,11 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     }
 
     /// The delegate of the floating panel controller object.
-    public weak var delegate: FloatingPanelControllerDelegate?
+    public weak var delegate: FloatingPanelControllerDelegate?{
+        didSet{
+            updateDelegate()
+        }
+    }
 
     /// Returns the surface view managed by the controller object. It's the same as `self.view`.
     public var surfaceView: FloatingPanelSurfaceView! {
@@ -140,7 +144,7 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     }
 
     /// Initialize a newly created floating panel controller.
-    public init(_ delegate: FloatingPanelControllerDelegate? = nil) {
+    public init(delegate: FloatingPanelControllerDelegate? = nil) {
         super.init(nibName: nil, bundle: nil)
         self.delegate = delegate
         setUp()
@@ -157,6 +161,13 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
                                       behavior: fetchBehavior(for: self.traitCollection))
     }
 
+    private func updateDelegate(){
+        reloadLayout(for: self.traitCollection)
+        setUpLayout()
+        
+        floatingPanel.behavior = fetchBehavior(for: self.traitCollection)
+    }
+    
     // MARK:- Overrides
 
     /// Creates the view that the controller manages.

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -140,8 +140,9 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     }
 
     /// Initialize a newly created floating panel controller.
-    public init() {
+    public init(_ delegate: FloatingPanelControllerDelegate? = nil) {
         super.init(nibName: nil, bundle: nil)
+        self.delegate = delegate
         setUp()
     }
 

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -72,7 +72,7 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     /// The delegate of the floating panel controller object.
     public weak var delegate: FloatingPanelControllerDelegate?{
         didSet{
-            updateDelegate()
+            didUpdateDelegate()
         }
     }
 
@@ -161,10 +161,8 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
                                       behavior: fetchBehavior(for: self.traitCollection))
     }
 
-    private func updateDelegate(){
-        reloadLayout(for: self.traitCollection)
-        setUpLayout()
-        
+    private func didUpdateDelegate(){
+        floatingPanel.layoutAdapter.layout = fetchLayout(for: traitCollection)
         floatingPanel.behavior = fetchBehavior(for: self.traitCollection)
     }
     


### PR DESCRIPTION
Typical use case is :

```
let floatingVC = FloatingPanelController()
floatingVC.delegate = self
```

This PR allows to set the delegate straight away by using `let floatingVC = FloatingPanelController(self)`
Its true reason is that the setup code that fetches behavior / layout through delegate is called without the delegate being set is useless on `init`ing.
Another implementation could be observing the `didSet` event on delegate to do the `setUp` for `FloatingPanel`

@SCENEE what do you think of this ?
Origin : I found this issue when migrating from 1.2.x to 1.3.1 where my custom behavior is not properly used.