### PR TITLE
Restore original scroll view delegate when updating content VC

### DIFF
--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -376,6 +376,12 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
             vc.willMove(toParentViewController: nil)
             vc.view.removeFromSuperview()
             vc.removeFromParentViewController()
+            
+            if let scrollView = floatingPanel.scrollView,
+                let delegate = floatingPanel.userScrollViewDelegate,
+                vc.view.subviews.contains(scrollView) {
+                scrollView.delegate = delegate
+            }
         }
 
         if let vc = contentViewController {


### PR DESCRIPTION
Fixes https://github.com/SCENEE/FloatingPanel/issues/113 

Test this as follows:
- create a floating panel with content view controller `A` that has a scroll view `alpha` with a delegate `X` (could be viewcontroller `A`)
- present the panel
- set the floating panel's content view controller to a view controller `B` with scroll view `beta` and a delegate `Y` (could be viewcontroller `B`)
- set the floating panel's content view controller back to view controller `A`
- note that the delegate of scroll view `alpha` is still `X`. Without this PR, the delegate is a `FloatingPanel` instance, instead of the original delegate `X`.