### PR TITLE
Improve the operability

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -107,8 +107,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             animator.addAnimations { [weak self] in
                 guard let `self` = self else { return }
 
-                self.updateLayout(to: to)
                 self.state = to
+                self.updateLayout(to: to)
             }
             animator.addCompletion { [weak self] _ in
                 guard let `self` = self else { return }
@@ -118,8 +118,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             self.animator = animator
             animator.startAnimation()
         } else {
-            self.updateLayout(to: to)
             self.state = to
+            self.updateLayout(to: to)
             completion?()
         }
     }
@@ -546,8 +546,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         let animator = behavior.interactionAnimator(self.viewcontroller, to: targetPosition, with: velocityVector)
         animator.addAnimations { [weak self] in
             guard let `self` = self else { return }
-            self.updateLayout(to: targetPosition)
             self.state = targetPosition
+            self.updateLayout(to: targetPosition)
         }
         animator.addCompletion { [weak self] pos in
             guard let `self` = self else { return }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -313,8 +313,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 }
                 panningChange(with: translation)
             case .ended, .cancelled, .failed:
-                // Uppdate the surface frame with the last translation
-                panningChange(with: translation)
                 panningEnd(with: translation, velocity: velocity)
             case .possible:
                 break
@@ -376,11 +374,25 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         log.debug("panningChange")
 
         let dy = translation.y - initialTranslationY
-        layoutAdapter.updateInteractiveTopConstraint(diff: dy)
+
+        layoutAdapter.updateInteractiveTopConstraint(diff: dy,
+                                                     allowsTopBuffer: allowsTopBuffer(for: dy))
+
         backdropView.alpha = getBackdropAlpha(with: translation)
         preserveContentVCLayoutIfNeeded()
 
         viewcontroller.delegate?.floatingPanelDidMove(viewcontroller)
+    }
+
+    private func allowsTopBuffer(for translationY: CGFloat) -> Bool {
+        let preY = surfaceView.frame.minY
+        let nextY = initialFrame.offsetBy(dx: 0.0, dy: translationY).minY
+        if let scrollView = scrollView, scrollView.panGestureRecognizer.state == .changed,
+            preY > 0 && preY > nextY {
+            return false
+        } else {
+            return true
+        }
     }
 
     private var disabledBottomAutoLayout = false

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -252,13 +252,17 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 // Scroll offset pinning
                 switch state {
                 case .full:
-                    let point = panGesture.location(in: surfaceView)
-                    if grabberAreaFrame.contains(point) {
-                        // Preserve the current content offset in moving from full.
-                        scrollView.contentOffset.y = initialScrollOffset.y
+                    if interactionInProgress {
+                        scrollView.setContentOffset(initialScrollOffset, animated: false)
                     } else {
-                        // Prevent over scrolling in moving from full.
-                        scrollView.contentOffset.y = scrollView.contentOffsetZero.y
+                        let point = panGesture.location(in: surfaceView)
+                        if grabberAreaFrame.contains(point) {
+                            // Preserve the current content offset in moving from full.
+                            scrollView.contentOffset.y = initialScrollOffset.y
+                        } else {
+                            // Prevent over scrolling in moving from full.
+                            scrollView.contentOffset.y = scrollView.contentOffsetZero.y
+                        }
                     }
                 case .half, .tip:
                     guard scrollView.isDecelerating == false else {

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -269,7 +269,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                     // Fix the scroll offset in moving the panel from half and tip.
                     scrollView.contentOffset.y = initialScrollOffset.y
                 case .hidden:
-                    fatalError("Now .hidden must not be used for a user interaction")
+                    break
                 }
 
                 // Always hide a scroll indicator at the non-top.

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -375,7 +375,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     private func panningChange(with translation: CGPoint) {
         log.debug("panningChange")
-
+        let pre = surfaceView.frame.minY
         let dy = translation.y - initialTranslationY
 
         layoutAdapter.updateInteractiveTopConstraint(diff: dy,
@@ -383,6 +383,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
         backdropView.alpha = getBackdropAlpha(with: translation)
         preserveContentVCLayoutIfNeeded()
+
+        let didMove = (pre != surfaceView.frame.minY)
+        guard didMove else { return }
 
         viewcontroller.delegate?.floatingPanelDidMove(viewcontroller)
     }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -92,6 +92,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         if to != .full {
             lockScrollView()
         }
+        tearDownActiveInteraction()
 
         if animated {
             let animator: UIViewPropertyAnimator
@@ -538,6 +539,12 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         }
 
         layoutAdapter.endInteraction(at: targetPosition)
+    }
+
+    private func tearDownActiveInteraction() {
+        // Cancel the pan gesture so that panningEnd(with:velocity:) is called
+        panGestureRecognizer.isEnabled = false
+        panGestureRecognizer.isEnabled = true
     }
 
     private func startAnimation(to targetPosition: FloatingPanelPosition, at distance: CGFloat, with velocity: CGPoint) {

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -673,7 +673,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             }
 
             let decelerationRate = behavior.momentumProjectionRate(viewcontroller)
-            let pY = project(initialVelocity: velocity.y, decelerationRate: decelerationRate) + currentY
+
+            let baseY = abs(bottomY - topY)
+            let vecY = velocity.y / baseY
+            let pY = project(initialVelocity: vecY, decelerationRate: decelerationRate) * baseY + currentY
 
             switch currentY {
             case ..<th1:

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -132,7 +132,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func getBackdropAlpha(with translation: CGPoint) -> CGFloat {
-        let currentY = getCurrentY(from: initialFrame, with: translation)
+        let currentY = surfaceView.frame.minY
 
         let next = directionalPosition(at: currentY, with: translation)
         let pre = redirectionalPosition(at: currentY, with: translation)
@@ -313,6 +313,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 }
                 panningChange(with: translation)
             case .ended, .cancelled, .failed:
+                // Uppdate the surface frame with the last translation
+                panningChange(with: translation)
                 panningEnd(with: translation, velocity: velocity)
             case .possible:
                 break
@@ -388,14 +390,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             return
         }
 
-        if interactionInProgress == false {
-            initialFrame = surfaceView.frame
-        }
-
         stopScrollDeceleration = (surfaceView.frame.minY > layoutAdapter.topY) // Projecting the dragging to the scroll dragging or not
 
-        let targetPosition = self.targetPosition(with: translation, velocity: velocity)
-        let distance = self.distance(to: targetPosition, with: translation)
+        let targetPosition = self.targetPosition(with: velocity)
+        let distance = self.distance(to: targetPosition)
 
         endInteraction(for: targetPosition)
 
@@ -403,7 +401,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             let velocityVector = (distance != 0) ? CGVector(dx: 0,
                                                             dy: min(fabs(velocity.y)/distance, behavior.removalVelocity)) : .zero
 
-            if shouldStartRemovalAnimation(with: translation, velocityVector: velocityVector) {
+            if shouldStartRemovalAnimation(with: velocityVector) {
 
                 viewcontroller.delegate?.floatingPanelDidEndDraggingToRemove(viewcontroller, withVelocity: velocity)
                 self.startRemovalAnimation(with: velocityVector) { [weak self] in
@@ -423,9 +421,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         startAnimation(to: targetPosition, at: distance, with: velocity)
     }
 
-    private func shouldStartRemovalAnimation(with translation: CGPoint, velocityVector: CGVector) -> Bool {
+    private func shouldStartRemovalAnimation(with velocityVector: CGVector) -> Bool {
         let posY = layoutAdapter.positionY(for: state)
-        let currentY = getCurrentY(from: initialFrame, with: translation)
+        let currentY = surfaceView.frame.minY
         let safeAreaBottomY = layoutAdapter.safeAreaBottomY
         let vth = behavior.removalVelocity
         let pth = max(min(behavior.removalProgress, 1.0), 0.0)
@@ -514,26 +512,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         }
     }
 
-    private func getCurrentY(from rect: CGRect, with translation: CGPoint) -> CGFloat {
-        let dy = translation.y - initialTranslationY
-        let y = rect.offsetBy(dx: 0.0, dy: dy).origin.y
-
-        let topY = layoutAdapter.topY
-        let topBuffer = layoutAdapter.layout.topInteractionBuffer
-        let bottomY = layoutAdapter.bottomY
-        let bottomBuffer = layoutAdapter.layout.bottomInteractionBuffer
-        let topMax = layoutAdapter.topMaxY
-        let bottomMax = layoutAdapter.bottomMaxY
-        
-        if let scrollView = scrollView, scrollView.panGestureRecognizer.state == .changed {
-            let preY = surfaceView.frame.origin.y
-            if preY > 0 && preY > y {
-                return max(max(topY, topMax), min(min(bottomY + bottomBuffer, bottomMax), y))
-            }
-        }
-        return max(max(topY - topBuffer, topMax), min(min(bottomY + bottomBuffer, bottomMax), y))
-    }
-
     private func startAnimation(to targetPosition: FloatingPanelPosition, at distance: CGFloat, with velocity: CGPoint) {
         log.debug("startAnimation", targetPosition, distance, velocity)
 
@@ -572,11 +550,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         }
     }
 
-    private func distance(to targetPosition: FloatingPanelPosition, with translation: CGPoint) -> CGFloat {
+    private func distance(to targetPosition: FloatingPanelPosition) -> CGFloat {
         let topY = layoutAdapter.topY
         let middleY = layoutAdapter.middleY
         let bottomY = layoutAdapter.bottomY
-        let currentY = getCurrentY(from: initialFrame, with: translation)
+        let currentY = surfaceView.frame.minY
 
         switch targetPosition {
         case .full:
@@ -627,8 +605,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         return (initialVelocity / 1000.0) * decelerationRate / (1.0 - decelerationRate)
     }
 
-    private func targetPosition(with translation: CGPoint, velocity: CGPoint) -> (FloatingPanelPosition) {
-        let currentY = getCurrentY(from: initialFrame, with: translation)
+    private func targetPosition(with velocity: CGPoint) -> (FloatingPanelPosition) {
+        let currentY = surfaceView.frame.minY
         let supportedPositions = layoutAdapter.supportedPositions
 
         if supportedPositions.count == 1 {

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -299,6 +299,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 self.animator = nil
             }
 
+            if interactionInProgress == false,
+                viewcontroller.delegate?.floatingPanelShouldBeginDragging(viewcontroller) == false {
+                return
+            }
+
             switch panGesture.state {
             case .began:
                 panningBegan()

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -234,22 +234,28 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     // MARK: - Gesture handling
     @objc func handle(panGesture: UIPanGestureRecognizer) {
-        log.debug("Gesture >>>>", panGesture)
         let velocity = panGesture.velocity(in: panGesture.view)
 
         switch panGesture {
         case scrollView?.panGestureRecognizer:
             guard let scrollView = scrollView else { return }
 
-            log.debug("SrollPanGesture ScrollView.contentOffset >>>", scrollView.contentOffset.y, scrollView.contentSize, scrollView.bounds.size)
-
             let location = panGesture.location(in: surfaceView)
 
-            if surfaceView.frame.minY > layoutAdapter.topY {
+            let belowTop = surfaceView.frame.minY > layoutAdapter.topY
+
+            log.debug("scroll gesture(\(state):\(panGesture.state)) --",
+                "belowTop = \(belowTop),",
+                "interactionInProgress = \(interactionInProgress),",
+                "scroll offset = \(scrollView.contentOffset.y),",
+                "location = \(location.y), velocity = \(velocity.y)")
+
+            if belowTop {
                 // Scroll offset pinning
                 switch state {
                 case .full:
                     if interactionInProgress {
+                        log.debug("settle offset --", initialScrollOffset.y)
                         scrollView.setContentOffset(initialScrollOffset, animated: false)
                     } else {
                         if grabberAreaFrame.contains(location) {
@@ -296,7 +302,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             let translation = panGesture.translation(in: panGestureRecognizer.view!.superview)
             let location = panGesture.location(in: panGesture.view)
 
-            log.debug(panGesture.state, ">>>", "translation: \(translation.y), velocity: \(velocity.y)")
+            log.debug("panel gesture(\(state):\(panGesture.state)) --",
+                "translation =  \(translation.y), location = \(location.y), velocity = \(velocity.y)")
 
             if let animator = self.animator {
                 if animator.isInterruptible {
@@ -371,8 +378,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             return false
         }
 
-        log.debug("ScrollView.contentOffset >>>", scrollView.contentOffset.y)
-
         let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
         // 10 pt is introduced from my testing(there might be better one)
         // It should be low as possible because a user scroll view frame will
@@ -396,7 +401,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         // A user interaction does not always start from Began state of the pan gesture
         // because it can be recognized in scrolling a content in a content view controller.
         // So here just preserve the current state if needed.
-        log.debug("panningBegan")
+        log.debug("panningBegan -- location = \(location.y)")
         initialLocation = location
         switch state {
         case .full:
@@ -411,7 +416,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func panningChange(with translation: CGPoint) {
-        log.debug("panningChange")
+        log.debug("panningChange -- translation = \(translation.y)")
         let pre = surfaceView.frame.minY
         let dy = translation.y - initialTranslationY
 
@@ -479,7 +484,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func panningEnd(with translation: CGPoint, velocity: CGPoint) {
-        log.debug("panningEnd")
+        log.debug("panningEnd -- translation = \(translation.y), velocity = \(velocity.y)")
 
         if state == .hidden {
             log.debug("Already hidden")
@@ -548,7 +553,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     private func startInteraction(with translation: CGPoint, at location: CGPoint) {
         /* Don't lock a scroll view to show a scroll indicator after hitting the top */
-        log.debug("startInteraction")
+        log.debug("startInteraction  -- translation = \(translation.y), location = \(location.y)")
         guard interactionInProgress == false else { return }
 
         initialFrame = surfaceView.frame
@@ -559,6 +564,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 settle(scrollView: scrollView)
                 initialScrollOffset = scrollView.contentOffsetZero
             }
+            log.debug("initial scroll offset --", initialScrollOffset)
         }
 
         initialTranslationY = translation.y
@@ -571,7 +577,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func endInteraction(for targetPosition: FloatingPanelPosition) {
-        log.debug("endInteraction for \(targetPosition)")
+        log.debug("endInteraction to \(targetPosition)")
+
+        if let scrollView = scrollView {
+            log.debug("endInteraction -- scroll offset = \(scrollView.contentOffset)")
+        }
 
         interactionInProgress = false
 
@@ -590,7 +600,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func startAnimation(to targetPosition: FloatingPanelPosition, at distance: CGFloat, with velocity: CGPoint) {
-        log.debug("startAnimation", targetPosition, distance, velocity)
+        log.debug("startAnimation to \(targetPosition) -- distance = \(distance), velocity = \(velocity.y)")
 
         isDecelerating = true
         viewcontroller.delegate?.floatingPanelWillBeginDecelerating(viewcontroller)
@@ -611,11 +621,15 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func finishAnimation(at targetPosition: FloatingPanelPosition) {
-        log.debug("finishAnimation \(targetPosition)")
+        log.debug("finishAnimation to \(targetPosition)")
         self.isDecelerating = false
         self.animator = nil
 
         self.viewcontroller.delegate?.floatingPanelDidEndDecelerating(self.viewcontroller)
+
+        if let scrollView = scrollView {
+            log.debug("finishAnimation -- scroll offset = \(scrollView.contentOffset)")
+        }
 
         stopScrollDeceleration = false
         // Don't unlock scroll view in animating view when presentation layer != model layer
@@ -842,6 +856,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func fitToBounds(scrollView: UIScrollView) {
+        log.debug("fit scroll view to bounds -- scroll offset =", scrollView.contentOffset.y)
+
         surfaceView.frame.origin.y = layoutAdapter.topY - scrollView.contentOffset.y
         scrollView.transform = CGAffineTransform.identity.translatedBy(x: 0.0,
                                                                        y: scrollView.contentOffset.y)
@@ -852,6 +868,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func settle(scrollView: UIScrollView) {
+        log.debug("settle scroll view")
+
         surfaceView.transform = .identity
         scrollView.transform = .identity
         scrollView.frame = initialScrollFrame

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -295,7 +295,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
             if let animator = self.animator {
                 if animator.isInterruptible {
-                    animator.stopAnimation(true)
+                    animator.stopAnimation(false)
+                    animator.finishAnimation(at: .current)
                 }
                 self.animator = nil
             }
@@ -562,11 +563,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         animator.addCompletion { [weak self] pos in
             guard let `self` = self else { return }
             self.isDecelerating = false
-            guard
-                self.interactionInProgress == false,
-                animator == self.animator,
-                pos == .end
-                else { return }
             self.animator = nil
             self.finishAnimation(at: targetPosition)
         }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -9,7 +9,7 @@ import UIKit.UIGestureRecognizerSubclass // For Xcode 9.4.1
 /// FloatingPanel presentation model
 ///
 class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate {
-    // MUST be a weak reference to prevent UI freeze on the presentaion modally
+    // MUST be a weak reference to prevent UI freeze on the presentation modally
     weak var viewcontroller: FloatingPanelController!
 
     let surfaceView: FloatingPanelSurfaceView
@@ -219,7 +219,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             // Do not begin the pan gesture until these gestures fail
             return true
         default:
-            // Should begin the pan gesture witout waiting tap/long press gestures fail
+            // Should begin the pan gesture without waiting tap/long press gestures fail
             return false
         }
     }
@@ -382,7 +382,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         // 10 pt is introduced from my testing(there might be better one)
         // It should be low as possible because a user scroll view frame will
         // change as far as the specified value temporarily.
-        // The zero offset is an excetpion because the offset is usually zero
+        // The zero offset is an exception because the offset is usually zero
         // when a panel moves from half or tip position to full.
         if  offset > -10.0, offset != 0.0 {
             return true
@@ -444,7 +444,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private var disabledBottomAutoLayout = false
-    // Prevent streching a view having a constraint to SafeArea.bottom in an overflow
+    // Prevent stretching a view having a constraint to SafeArea.bottom in an overflow
     // from the full position because SafeArea is global in a screen.
     private func preserveContentVCLayoutIfNeeded() {
         // Must include topY
@@ -585,7 +585,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
         interactionInProgress = false
 
-        // Prevent to keep a scoll view indicator visible at the half/tip position
+        // Prevent to keep a scroll view indicator visible at the half/tip position
         if targetPosition != .full {
             lockScrollView()
         }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -477,7 +477,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         }
 
         viewcontroller.delegate?.floatingPanelDidEndDragging(viewcontroller, withVelocity: velocity, targetPosition: targetPosition)
-        viewcontroller.delegate?.floatingPanelWillBeginDecelerating(viewcontroller)
 
         startAnimation(to: targetPosition, at: distance, with: velocity)
     }
@@ -552,6 +551,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         log.debug("startAnimation", targetPosition, distance, velocity)
 
         isDecelerating = true
+        viewcontroller.delegate?.floatingPanelWillBeginDecelerating(viewcontroller)
 
         let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: min(fabs(velocity.y)/distance, 30.0)) : .zero
         let animator = behavior.interactionAnimator(self.viewcontroller, to: targetPosition, with: velocityVector)
@@ -562,8 +562,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         }
         animator.addCompletion { [weak self] pos in
             guard let `self` = self else { return }
-            self.isDecelerating = false
-            self.animator = nil
             self.finishAnimation(at: targetPosition)
         }
         self.animator = animator
@@ -572,6 +570,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     private func finishAnimation(at targetPosition: FloatingPanelPosition) {
         log.debug("finishAnimation \(targetPosition)")
+        self.isDecelerating = false
+        self.animator = nil
+
         self.viewcontroller.delegate?.floatingPanelDidEndDecelerating(self.viewcontroller)
 
         stopScrollDeceleration = false

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -424,12 +424,12 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     private func shouldStartRemovalAnimation(with velocityVector: CGVector) -> Bool {
         let posY = layoutAdapter.positionY(for: state)
         let currentY = surfaceView.frame.minY
-        let safeAreaBottomY = layoutAdapter.safeAreaBottomY
+        let bottomMaxY = layoutAdapter.bottomMaxY
         let vth = behavior.removalVelocity
         let pth = max(min(behavior.removalProgress, 1.0), 0.0)
 
         let num = (currentY - posY)
-        let den = (safeAreaBottomY - posY)
+        let den = (bottomMaxY - posY)
 
         guard num >= 0, den != 0, (num / den >= pth || velocityVector.dy == vth)
         else { return false }

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -6,7 +6,18 @@
 import UIKit
 
 public protocol FloatingPanelBehavior {
-    /// Returns the progress to redirect to the previous position
+    /// Asks the behavior object if the floating panel should project a momentum of a user interaction to move the proposed position.
+    ///
+    /// The default implementation of this method returns true. This method is called for a layout to support all positions(tip, half and full).
+    /// Therfore, `proposedTargetPosition` can only be `FloatingPanelPosition.tip` or `FloatingPanelPosition.full`.
+    func shouldProjectMomentum(_ fpc: FloatingPanelController, for proposedTargetPosition: FloatingPanelPosition) -> Bool
+
+    /// Returns a deceleration rate to calculate a target position projected a dragging momentum.
+    ///
+    /// The default implementation of this method returns the normal deceleration rate of UIScrollView.
+    func momentumProjectionRate(_ fpc: FloatingPanelController) -> CGFloat
+
+    /// Returns the progress to redirect to the previous position.
     ///
     /// The progress is represented by a floating-point value between 0.0 and 1.0, inclusive, where 1.0 indicates the floating panel is impossible to move to the next posiiton. The default value is 0.5. Values less than 0.0 and greater than 1.0 are pinned to those limits.
     func redirectionalProgress(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> CGFloat
@@ -49,6 +60,14 @@ public protocol FloatingPanelBehavior {
 }
 
 public extension FloatingPanelBehavior {
+    func shouldProjectMomentum(_ fpc: FloatingPanelController, for proposedTargetPosition: FloatingPanelPosition) -> Bool {
+        return true
+    }
+
+    func momentumProjectionRate(_ fpc: FloatingPanelController) -> CGFloat {
+        return UIScrollViewDecelerationRateNormal
+    }
+
     func redirectionalProgress(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> CGFloat {
         return 0.5
     }

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -61,7 +61,14 @@ public protocol FloatingPanelBehavior {
 
 public extension FloatingPanelBehavior {
     func shouldProjectMomentum(_ fpc: FloatingPanelController, for proposedTargetPosition: FloatingPanelPosition) -> Bool {
-        return true
+        switch (fpc.position, proposedTargetPosition) {
+        case (.full, .tip):
+            return false
+        case (.tip,  .full):
+            return false
+        default:
+            return true
+        }
     }
 
     func momentumProjectionRate(_ fpc: FloatingPanelController) -> CGFloat {

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -53,6 +53,10 @@ public extension FloatingPanelBehavior {
         return 0.5
     }
 
+    public func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
+        return defaultBehavior.interactionAnimator(fpc, to: targetPosition, with: velocity)
+    }
+
     func addAnimator(_ fpc: FloatingPanelController, to: FloatingPanelPosition) -> UIViewPropertyAnimator {
         return UIViewPropertyAnimator(duration: 0.25, curve: .easeInOut)
     }
@@ -82,8 +86,12 @@ public extension FloatingPanelBehavior {
     }
 }
 
-class FloatingPanelDefaultBehavior: FloatingPanelBehavior {
-    func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
+private let defaultBehavior = FloatingPanelDefaultBehavior()
+
+public class FloatingPanelDefaultBehavior: FloatingPanelBehavior {
+    public init() { }
+
+    public func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
         let timing = timeingCurve(with: velocity)
         let animator = UIViewPropertyAnimator(duration: 0, timingParameters: timing)
         animator.isInterruptible = false

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -392,7 +392,7 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
             vc.willMove(toParentViewController: nil)
             vc.view.removeFromSuperview()
             vc.removeFromParentViewController()
-            
+
             if let scrollView = floatingPanel.scrollView,
                 let delegate = floatingPanel.userScrollViewDelegate,
                 vc.view.subviews.contains(scrollView) {
@@ -428,10 +428,22 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
 
     /// Tracks the specified scroll view to correspond with the scroll.
     ///
+    /// - Parameters:
+    ///     - scrollView: Specify a scroll view to continuously and seamlessly work in concert with interactions of the surface view or nil to cancel it.
     /// - Attention:
     ///     The specified scroll view must be already assigned to the delegate property because the controller intermediates between the various delegate methods.
-    ///
-    public func track(scrollView: UIScrollView) {
+    public func track(scrollView: UIScrollView?) {
+        if let trackingScrollView = floatingPanel.scrollView,
+            let delegate = floatingPanel.userScrollViewDelegate {
+            trackingScrollView.delegate = delegate // restore delegate
+            floatingPanel.userScrollViewDelegate = nil
+        }
+
+        guard let scrollView = scrollView else {
+            floatingPanel.scrollView = nil
+            return
+        }
+
         floatingPanel.scrollView = scrollView
         if scrollView.delegate !== floatingPanel {
             floatingPanel.userScrollViewDelegate = scrollView.delegate

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -244,10 +244,8 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     }
 
     private func update(safeAreaInsets: UIEdgeInsets) {
-        // Don't re-layout the surface on SafeArea.Bottom enabled/disabled in interaction progress
         guard
             floatingPanel.layoutAdapter.safeAreaInsets != safeAreaInsets,
-            self.floatingPanel.interactionInProgress == false,
             self.floatingPanel.isDecelerating == false
             else { return }
 

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -14,7 +14,10 @@ public protocol FloatingPanelControllerDelegate: class {
 
     func floatingPanelDidChangePosition(_ vc: FloatingPanelController) // changed the settled position in the model layer
 
-    func floatingPanelDidMove(_ vc: FloatingPanelController) // any offset changes
+    /// Asks the delegate if dragging should begin by the pan gesture recognizer.
+    func floatingPanelShouldBeginDragging(_ vc: FloatingPanelController) -> Bool
+
+    func floatingPanelDidMove(_ vc: FloatingPanelController) // any surface frame changes in dragging
 
     // called on start of dragging (may require some time and or distance to move)
     func floatingPanelWillBeginDragging(_ vc: FloatingPanelController)
@@ -28,7 +31,10 @@ public protocol FloatingPanelControllerDelegate: class {
     // called when its views are removed from a parent view controller
     func floatingPanelDidEndRemove(_ vc: FloatingPanelController)
 
-    func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool
+    /// Asks the delegate if the other gesture recognizer should be allowed to recognize the gesture in parallel.
+    ///
+    /// By default, any tap and long gesture recognizers are allowed to recognize gestures simultaneously.
+    func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool
 }
 
 public extension FloatingPanelControllerDelegate {
@@ -39,6 +45,9 @@ public extension FloatingPanelControllerDelegate {
         return nil
     }
     func floatingPanelDidChangePosition(_ vc: FloatingPanelController) {}
+    func floatingPanelShouldBeginDragging(_ vc: FloatingPanelController) -> Bool {
+        return true
+    }
     func floatingPanelDidMove(_ vc: FloatingPanelController) {}
     func floatingPanelWillBeginDragging(_ vc: FloatingPanelController) {}
     func floatingPanelDidEndDragging(_ vc: FloatingPanelController, withVelocity velocity: CGPoint, targetPosition: FloatingPanelPosition) {}
@@ -48,7 +57,9 @@ public extension FloatingPanelControllerDelegate {
     func floatingPanelDidEndDraggingToRemove(_ vc: FloatingPanelController, withVelocity velocity: CGPoint) {}
     func floatingPanelDidEndRemove(_ vc: FloatingPanelController) {}
 
-    func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool { return false }
+    func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false
+    }
 }
 
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -428,7 +428,7 @@ class FloatingPanelLayoutAdapter {
         }
     }
 
-    func setBackdropAlpha(of target: FloatingPanelPosition) {
+    private func setBackdropAlpha(of target: FloatingPanelPosition) {
         if target == .hidden {
             self.backdropView.alpha = 0.0
         } else {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -95,6 +95,8 @@ public extension FloatingPanelLayout {
 }
 
 public class FloatingPanelDefaultLayout: FloatingPanelLayout {
+    public init() { }
+
     public var initialPosition: FloatingPanelPosition {
         return .half
     }
@@ -110,6 +112,8 @@ public class FloatingPanelDefaultLayout: FloatingPanelLayout {
 }
 
 public class FloatingPanelDefaultLandscapeLayout: FloatingPanelLayout {
+    public init() { }
+
     public var initialPosition: FloatingPanelPosition {
         return .tip
     }

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -294,7 +294,7 @@ class FloatingPanelLayoutAdapter {
 
         fixedConstraints = surfaceConstraints + backdropConstraints
 
-        // Flexible surface constarints for full, half, tip and off
+        // Flexible surface constraints for full, half, tip and off
         let topAnchor: NSLayoutYAxisAnchor = {
             if layout is FloatingPanelFullScreenLayout {
                 return vc.view.topAnchor
@@ -357,7 +357,7 @@ class FloatingPanelLayoutAdapter {
     }
 
     func endInteraction(at state: FloatingPanelPosition) {
-        // Don't deacitvate `interactiveTopConstraint` here because it leads to
+        // Don't deactivate `interactiveTopConstraint` here because it leads to
         // unsatisfiable constraints
     }
 

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -114,7 +114,7 @@ public class FloatingPanelSurfaceView: UIView {
 
     public override func layoutSubviews() {
         super.layoutSubviews()
-        log.debug("SurfaceView frame", frame)
+        log.debug("surface view frame = \(frame)")
 
         updateLayers()
         updateContentViewMask()
@@ -125,8 +125,6 @@ public class FloatingPanelSurfaceView: UIView {
     }
 
     private func updateLayers() {
-        log.debug("SurfaceView bounds", bounds)
-
         backgroundView.backgroundColor = color
         backgroundView.layer.masksToBounds = true
         backgroundView.layer.cornerRadius = cornerRadius

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -13,7 +13,7 @@ public class FloatingPanelSurfaceView: UIView {
     /// A GrabberHandleView object displayed at the top of the surface view.
     ///
     /// To use a custom grabber handle, hide this and then add the custom one
-    /// to the surface view at appropirate coordinates.
+    /// to the surface view at appropriate coordinates.
     public var grabberHandle: GrabberHandleView!
 
     /// The height of the grabber bar area
@@ -140,7 +140,7 @@ public class FloatingPanelSurfaceView: UIView {
     private func updateContentViewMask() {
         if #available(iOS 11, *) {
             // Don't use `contentView.clipToBounds` because it prevents content view from expanding the height of a subview of it
-            // for the bottom overflow like Auto Layout settings of UIVisualEffectView in Main.storyborad of Example/Maps.
+            // for the bottom overflow like Auto Layout settings of UIVisualEffectView in Main.storyboard of Example/Maps.
             // Because the bottom of contentView must be fit to the bottom of a screen to work the `safeLayoutGuide` of a content VC.
             contentView?.layer.masksToBounds = true
             contentView?.layer.cornerRadius = cornerRadius

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -24,7 +24,7 @@ class FloatingPanelModalTransition: NSObject, UIViewControllerTransitioningDeleg
 class FloatingPanelPresentationController: UIPresentationController {
     override func presentationTransitionWillBegin() {
         // Must call here even if duplicating on in containerViewWillLayoutSubviews()
-        // Because it let the floating panel present correclty with the presentation animation
+        // Because it let the floating panel present correctly with the presentation animation
         addFloatingPanel()
     }
 
@@ -52,14 +52,14 @@ class FloatingPanelPresentationController: UIPresentationController {
 
         /*
          * Layout the views managed by `FloatingPanelController` here for the
-         * sake of the presentation and disimissal modally from the controller.
+         * sake of the presentation and dismissal modally from the controller.
          */
         addFloatingPanel()
 
         // Forward touch events to the presenting view controller
         (fpc.view as? FloatingPanelPassThroughView)?.eventForwardingView = presentingViewController.view
 
-        // Set tap-to-dimiss in the backdrop view
+        // Set tap-to-dismiss in the backdrop view
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
         fpc.backdropView.addGestureRecognizer(tapGesture)
     }

--- a/Framework/Sources/UIExtensions.swift
+++ b/Framework/Sources/UIExtensions.swift
@@ -101,3 +101,10 @@ extension UISpringTimingParameters {
         self.init(mass: mass, stiffness: stiffness, damping: damp, initialVelocity: initialVelocity)
     }
 }
+
+extension CGPoint {
+    static var nan: CGPoint {
+        return CGPoint(x: CGFloat.nan,
+                       y: CGFloat.nan)
+    }
+}

--- a/Framework/Sources/UIExtensions.swift
+++ b/Framework/Sources/UIExtensions.swift
@@ -77,12 +77,12 @@ extension UIView {
 extension UIGestureRecognizerState: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
-        case .began: return "Began"
-        case .changed: return "Changed"
-        case .failed: return "Failed"
-        case .cancelled: return "Cancelled"
-        case .ended: return "Endeded"
-        case .possible: return "Possible"
+        case .began: return "began"
+        case .changed: return "changed"
+        case .failed: return "failed"
+        case .cancelled: return "cancelled"
+        case .ended: return "endeded"
+        case .possible: return "possible"
         }
     }
 }


### PR DESCRIPTION
## New API

**FloatingPanelController**

Enable to cancel the scroll view tracking 
```diff
- public func track(scrollView: UIScrollView) {
+ public func track(scrollView: UIScrollView?) {
```
**FloatingPanelControllerDelegate**

You can stop to begin dragging on the conditions. It's useful to handle other pan gestures or touches simultaneously with a floating panel.

```diff
+ public func floatingPanelShouldBeginDragging(_:)
```

**FloatingPanelBehavior**

Add  2 methods to configure the momentum projection
```diff
+ func shouldProjectMomentum(_ fpc: FloatingPanelController, for proposedTargetPosition: FloatingPanelPosition) -> Bool`
+ func momentumProjectionRate(_ fpc: FloatingPanelController) -> CGFloat
```

**FloatingPanelFullScreenLayout**

You can configure all insets of the surface from the superview(FloatingPanelController.view), not from the safe area.

## Improvements

**Core**

* Move the surface view by a top layout constraint, not by modifying the frame directly.
* Should always recognize tap/long press gestures in parallel -> v1.3.5
* Normalize the projected position
* Modify disabling the bottom constraint on top overflow.

**Layout/Behavior**

* ~~Make the default animation interruptible by the pan gesture~~
* Open the default layout/behavior

**Samples**

* Add a sample of the advanced layout animation

## Bugfixes

* Fix #133: FloatingPanel can be dragged outside safe area (with new logic)