### PR TITLE
Fix interaction

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -154,9 +154,19 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             return true
         }
 
-        // all gestures of the tracking scroll view should be recognized in parallel
-        // and handle them in self.handle(panGesture:)
-        return scrollView?.gestureRecognizers?.contains(otherGestureRecognizer) ?? false
+        switch otherGestureRecognizer {
+        case is UIPanGestureRecognizer,
+             is UISwipeGestureRecognizer,
+             is UIRotationGestureRecognizer,
+             is UIScreenEdgePanGestureRecognizer,
+             is UIPinchGestureRecognizer:
+            // all gestures of the tracking scroll view should be recognized in parallel
+            // and handle them in self.handle(panGesture:)
+            return scrollView?.gestureRecognizers?.contains(otherGestureRecognizer) ?? false
+        default:
+            // Should always recognize tap/long press gestures in parallel
+            return true
+        }
     }
 
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -266,7 +266,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                     // Fix the scroll offset in moving the panel from half and tip.
                     scrollView.contentOffset.y = initialScrollOffset.y + (initialScrollInset.top - scrollView.contentInset.top)
                 case .hidden:
-                    fatalError("A floating panel hidden must not be used by a user")
+                    fatalError("Now .hidden must not be used for a user interaction")
                 }
 
                 // Always hide a scroll indicator at the non-top.
@@ -581,7 +581,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         case .tip:
             return CGFloat(fabs(Double(currentY - bottomY)))
         case .hidden:
-            fatalError("A floating panel hidden must not be used by a user")
+            fatalError("Now .hidden must not be used for a user interaction")
         }
     }
 
@@ -646,29 +646,27 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             let middleY = layoutAdapter.middleY
             let bottomY = layoutAdapter.bottomY
 
-            let target: FloatingPanelPosition
+            let nextState: FloatingPanelPosition
             let forwardYDirection: Bool
 
+            /*
+             full <-> half <-> tip
+             */
             switch state {
             case .full:
-                target = .half
+                nextState = .half
                 forwardYDirection = true
             case .half:
-                if (currentY < middleY) {
-                    target = .full
-                    forwardYDirection = false
-                } else {
-                    target = .tip
-                    forwardYDirection = true
-                }
+                nextState = (currentY > middleY) ? .tip : .full
+                forwardYDirection = (currentY > middleY)
             case .tip:
-                target = .half
+                nextState = .half
                 forwardYDirection = false
             case .hidden:
-                fatalError("A floating panel hidden must not be used by a user")
+                fatalError("Now .hidden must not be used for a user interaction")
             }
 
-            let redirectionalProgress = max(min(behavior.redirectionalProgress(viewcontroller, from: state, to: target), 1.0), 0.0)
+            let redirectionalProgress = max(min(behavior.redirectionalProgress(viewcontroller, from: state, to: nextState), 1.0), 0.0)
 
             let th1: CGFloat
             let th2: CGFloat

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -523,7 +523,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         if let scrollView = scrollView, scrollView.panGestureRecognizer.state == .changed {
             let preY = surfaceView.frame.origin.y
             if preY > 0 && preY > y {
-                return max(topY, min(min(bottomY + bottomBuffer, bottomMax), y))
+                return max(max(topY, topMax), min(min(bottomY + bottomBuffer, bottomMax), y))
             }
         }
         return max(max(topY - topBuffer, topMax), min(min(bottomY + bottomBuffer, bottomMax), y))

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -807,7 +807,12 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             targetContentOffset.pointee = scrollView.contentOffset
             stopScrollDeceleration = false
         } else {
+            let targetOffset = targetContentOffset.pointee
             userScrollViewDelegate?.scrollViewWillEndDragging?(scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset)
+            // Stop scrolling on tip and half
+            if state != .full, targetOffset == targetContentOffset.pointee {
+                targetContentOffset.pointee.y = scrollView.contentOffset.y
+            }
         }
     }
 }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -108,9 +108,12 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 self.updateLayout(to: to)
                 self.state = to
             }
-            animator.addCompletion { _ in
+            animator.addCompletion { [weak self] _ in
+                guard let `self` = self else { return }
+                self.animator = nil
                 completion?()
             }
+            self.animator = animator
             animator.startAnimation()
         } else {
             self.updateLayout(to: to)
@@ -438,8 +441,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             self?.updateLayout(to: .hidden)
         }
         animator.addCompletion({ _ in
+            self.animator = nil
             completion?()
         })
+        self.animator = animator
         animator.startAnimation()
     }
 
@@ -544,15 +549,15 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 animator == self.animator,
                 pos == .end
                 else { return }
+            self.animator = nil
             self.finishAnimation(at: targetPosition)
         }
-        animator.startAnimation()
         self.animator = animator
+        animator.startAnimation()
     }
 
     private func finishAnimation(at targetPosition: FloatingPanelPosition) {
         log.debug("finishAnimation \(targetPosition)")
-        self.animator = nil
         self.viewcontroller.delegate?.floatingPanelDidEndDecelerating(self.viewcontroller)
 
         stopScrollDeceleration = false

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -45,6 +45,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     private var transOffsetY: CGFloat = 0
 
     var interactionInProgress: Bool = false
+    var isDecelerating: Bool = false
 
     // Scroll handling
     private var stopScrollDeceleration: Bool = false
@@ -520,6 +521,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     private func startAnimation(to targetPosition: FloatingPanelPosition, at distance: CGFloat, with velocity: CGPoint) {
         log.debug("startAnimation", targetPosition, distance, velocity)
         let targetY = layoutAdapter.positionY(for: targetPosition)
+
+        isDecelerating = true
+
         let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: max(min(velocity.y/distance, 30.0), -30.0)) : .zero
         let animator = behavior.interactionAnimator(self.viewcontroller, to: targetPosition, with: velocityVector)
         animator.addAnimations { [weak self] in
@@ -534,6 +538,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         }
         animator.addCompletion { [weak self] pos in
             guard let `self` = self else { return }
+            self.isDecelerating = false
             guard
                 self.interactionInProgress == false,
                 animator == self.animator,

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -236,8 +236,9 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
         // Don't re-layout the surface on SafeArea.Bottom enabled/disabled in interaction progress
         guard
             floatingPanel.layoutAdapter.safeAreaInsets != safeAreaInsets,
-            self.floatingPanel.interactionInProgress == false
-        else { return }
+            self.floatingPanel.interactionInProgress == false,
+            self.floatingPanel.isDecelerating == false
+            else { return }
 
         log.debug("Update safeAreaInsets", safeAreaInsets)
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -206,7 +206,7 @@ class FloatingPanelLayoutAdapter {
     }
 
     var topMaxY: CGFloat {
-        return layout is FloatingPanelFullScreenLayout ? 0.0 : -safeAreaInsets.top
+        return layout is FloatingPanelFullScreenLayout ? 0.0 : safeAreaInsets.top
     }
     var bottomMaxY: CGFloat { return safeAreaBottomY }
 


### PR DESCRIPTION
This will be released in v1.3.5.

## Bugfixes

* Don't block tap/long press gestures(Always recognize them in parallel)
* Stop interrupting a content offset of a tracking scroll view at the end of an interaction
* Fix the wrong layout update in iOS10
* Fix an interruptive animation (Now a user can use an interruptive animation safely)
* Fix backdrop handling on an animation interrupt
* Fix #133: FloatingPanel can be dragged outside safe area