### PR TITLE
Fix typo

### DIFF
--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -477,7 +477,7 @@ class FloatingPanelLayoutAdapter {
         // Verify layout configurations
         assert(supportedPositions.count > 0)
         assert(supportedPositions.union([.hidden]).contains(layout.initialPosition),
-               "Does not include an initial potision(\(layout.initialPosition)) in supportedPositions(\(supportedPositions))")
+               "Does not include an initial position (\(layout.initialPosition)) in supportedPositions(\(supportedPositions))")
 
         if layout is FloatingPanelIntrinsicLayout {
             assert(layout.insetFor(position: .full) == nil, "Return `nil` for full position on FloatingPanelIntrinsicLayout")

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -477,7 +477,7 @@ class FloatingPanelLayoutAdapter {
         // Verify layout configurations
         assert(supportedPositions.count > 0)
         assert(supportedPositions.union([.hidden]).contains(layout.initialPosition),
-               "Does not include an initial position (\(layout.initialPosition)) in supportedPositions(\(supportedPositions))")
+               "Does not include an initial position (\(layout.initialPosition)) in supportedPositions (\(supportedPositions))")
 
         if layout is FloatingPanelIntrinsicLayout {
             assert(layout.insetFor(position: .full) == nil, "Return `nil` for full position on FloatingPanelIntrinsicLayout")


### PR DESCRIPTION
As per title, this PR fixes a typo in one of the framework assertions (potision -> position).

I've also added a space between a couple of words and the open bracket next to them, as it is more proper 👍 

Please keep up the awesome work!! 💪💪💪 