### PR TITLE
[Release v1.5.0] Support both of Swift 5 and 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: swift
 branches:
   only:
     - master
-    - next
 cache:
   directories:
   - /usr/local/Homebrew
@@ -19,15 +18,20 @@ jobs:
   - stage: Build framework(swift 4.1)
     osx_image: xcode9.4
     script:
-    - xcodebuild -scheme FloatingPanel clean build
+    - xcodebuild -scheme FloatingPanel SWIFT_VERSION=4.1 clean build
 
   - stage: Build framework(swift 4.2)
     osx_image: xcode10
     script:
-    - xcodebuild -scheme FloatingPanel clean build
+    - xcodebuild -scheme FloatingPanel SWIFT_VERSION=4.2 clean build
+
+  - stage: Build framework(swift 5.0)
+    osx_image: xcode10.2
+    script:
+    - xcodebuild -scheme FloatingPanel SWIFT_VERSION=5.0 clean build
 
   - stage: Carthage
-    osx_image: xcode10
+    osx_image: xcode10.2
     before_install:
     - brew update
     - brew outdated carthage || brew upgrade carthage
@@ -35,21 +39,21 @@ jobs:
     - carthage build --no-skip-current
 
   - stage: Podspec
-    osx_image: xcode10
+    osx_image: xcode10.2
     script:
     - pod spec lint
 
   - stage: Build maps example
-    osx_image: xcode10
+    osx_image: xcode10.2
     script:
     - xcodebuild -scheme Maps -sdk iphonesimulator clean build
 
   - stage: Build stocks example
-    osx_image: xcode10
+    osx_image: xcode10.2
     script:
     - xcodebuild -scheme Stocks -sdk iphonesimulator clean build
 
   - stage: Build samples example
-    osx_image: xcode10
+    osx_image: xcode10.2
     script:
     - xcodebuild -scheme Samples -sdk iphonesimulator clean build

--- a/Examples/Maps/Maps.xcodeproj/project.pbxproj
+++ b/Examples/Maps/Maps.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.scenee.Maps;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -331,7 +331,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.scenee.Maps;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Examples/Samples/Samples.xcodeproj/project.pbxproj
+++ b/Examples/Samples/Samples.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.scenee.FloatingPanelSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -518,7 +518,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.scenee.FloatingPanelSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Examples/Stocks/Stocks.xcodeproj/project.pbxproj
+++ b/Examples/Stocks/Stocks.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.scenee.Stocks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -331,7 +331,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.scenee.Stocks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/FloatingPanel.podspec
+++ b/FloatingPanel.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                = "FloatingPanel"
-  s.version             = "1.4.1"
+  s.version             = "1.5.0"
   s.summary             = "FloatingPanel is a clean and easy-to-use UI component of a floating panel interface."
   s.description         = <<-DESC
 FloatingPanel is a clean and easy-to-use UI component for a new interface introduced in Apple Maps, Shortcuts and Stocks app.

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -307,7 +307,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 self.animator = nil
 
                 // A user can stop a panel at the nearest Y of a target position
-                if fabs(surfaceView.frame.minY - layoutAdapter.topY) < 1 {
+                if abs(surfaceView.frame.minY - layoutAdapter.topY) < 1 {
                     surfaceView.frame.origin.y = layoutAdapter.topY
                 }
             }
@@ -502,7 +502,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
         if isRemovalInteractionEnabled, isBottomState {
             let velocityVector = (distance != 0) ? CGVector(dx: 0,
-                                                            dy: min(fabs(velocity.y)/distance, behavior.removalVelocity)) : .zero
+                                                            dy: min(abs(velocity.y)/distance, behavior.removalVelocity)) : .zero
 
             if shouldStartRemovalAnimation(with: velocityVector) {
 
@@ -619,7 +619,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         isDecelerating = true
         viewcontroller.delegate?.floatingPanelWillBeginDecelerating(viewcontroller)
 
-        let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: min(fabs(velocity.y)/distance, 30.0)) : .zero
+        let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: min(abs(velocity.y)/distance, 30.0)) : .zero
         let animator = behavior.interactionAnimator(self.viewcontroller, to: targetPosition, with: velocityVector)
         animator.addAnimations { [weak self] in
             guard let `self` = self else { return }
@@ -660,11 +660,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
         switch targetPosition {
         case .full:
-            return CGFloat(fabs(currentY - topY))
+            return CGFloat(abs(currentY - topY))
         case .half:
-            return CGFloat(fabs(currentY - middleY))
+            return CGFloat(abs(currentY - middleY))
         case .tip:
-            return CGFloat(fabs(currentY - bottomY))
+            return CGFloat(abs(currentY - bottomY))
         case .hidden:
             fatalError("Now .hidden must not be used for a user interaction")
         }
@@ -703,7 +703,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     // Distance travelled after decelerating to zero velocity at a constant rate.
     // Refer to the slides p176 of [Designing Fluid Interfaces](https://developer.apple.com/videos/play/wwdc2018/803/)
-    private func project(initialVelocity: CGFloat, decelerationRate: CGFloat = UIScrollViewDecelerationRateNormal) -> CGFloat {
+    private func project(initialVelocity: CGFloat, decelerationRate: CGFloat) -> CGFloat {
         return (initialVelocity / 1000.0) * decelerationRate / (1.0 - decelerationRate)
     }
 

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -72,14 +72,18 @@ public extension FloatingPanelBehavior {
     }
 
     func momentumProjectionRate(_ fpc: FloatingPanelController) -> CGFloat {
+        #if swift(>=4.2)
+        return UIScrollView.DecelerationRate.normal.rawValue
+        #else
         return UIScrollViewDecelerationRateNormal
+        #endif
     }
 
     func redirectionalProgress(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> CGFloat {
         return 0.5
     }
 
-    public func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
+    func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
         return defaultBehavior.interactionAnimator(fpc, to: targetPosition, with: velocity)
     }
 

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -351,7 +351,11 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
             parent.view.addSubview(self.view)
         }
 
+        #if swift(>=4.2)
+        parent.addChild(self)
+        #else
         parent.addChildViewController(self)
+        #endif
 
         view.frame = parent.view.bounds // Needed for a correct safe area configuration
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -364,7 +368,11 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
 
         show(animated: animated) { [weak self] in
             guard let `self` = self else { return }
+            #if swift(>=4.2)
+            self.didMove(toParent: self)
+            #else
             self.didMove(toParentViewController: self)
+            #endif
         }
     }
 
@@ -380,9 +388,20 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
 
         hide(animated: animated) { [weak self] in
             guard let `self` = self else { return }
+            #if swift(>=4.2)
+            self.willMove(toParent: nil)
+            #else
             self.willMove(toParentViewController: nil)
+            #endif
+
             self.view.removeFromSuperview()
+
+            #if swift(>=4.2)
+            self.removeFromParent()
+            #else
             self.removeFromParentViewController()
+            #endif
+
             completion?()
         }
     }
@@ -400,16 +419,36 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
     /// Sets the view controller responsible for the content portion of the floating panel.
     public func set(contentViewController: UIViewController?) {
         if let vc = _contentViewController {
+            #if swift(>=4.2)
+            vc.willMove(toParent: nil)
+            #else
             vc.willMove(toParentViewController: nil)
+            #endif
+
             vc.view.removeFromSuperview()
+
+            #if swift(>=4.2)
+            vc.removeFromParent()
+            #else
             vc.removeFromParentViewController()
+            #endif
         }
 
         if let vc = contentViewController {
+            #if swift(>=4.2)
+            addChild(vc)
+            #else
             addChildViewController(vc)
+            #endif
+
             let surfaceView = floatingPanel.surfaceView
             surfaceView.add(contentView: vc.view)
+
+            #if swift(>=4.2)
+            vc.didMove(toParent: self)
+            #else
             vc.didMove(toParentViewController: self)
+            #endif
         }
 
         _contentViewController = contentViewController
@@ -448,9 +487,15 @@ public class FloatingPanelController: UIViewController, UIScrollViewDelegate, UI
             if #available(iOS 11.0, *) {
                 scrollView.contentInsetAdjustmentBehavior = .never
             } else {
+                #if swift(>=4.2)
+                children.forEach { (vc) in
+                    vc.automaticallyAdjustsScrollViewInsets = false
+                }
+                #else
                 childViewControllers.forEach { (vc) in
                     vc.automaticallyAdjustsScrollViewInsets = false
                 }
+                #endif
             }
         default:
             break
@@ -504,10 +549,10 @@ extension FloatingPanelController {
 }
 
 public extension UIViewController {
-    @objc public func fp_original_dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    @objc func fp_original_dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         // Implementation will be replaced by IMP of self.dismiss(animated:completion:)
     }
-    @objc public func fp_dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    @objc func fp_dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         // Call dismiss(animated:completion:) to a content view controller
         if let fpc = parent as? FloatingPanelController {
             if fpc.presentingViewController != nil {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -270,7 +270,11 @@ class FloatingPanelLayoutAdapter {
     }
 
     func updateIntrinsicHeight() {
+        #if swift(>=4.2)
+        let fittingSize = UIView.layoutFittingCompressedSize
+        #else
         let fittingSize = UILayoutFittingCompressedSize
+        #endif
         var intrinsicHeight = surfaceView.contentView?.systemLayoutSizeFitting(fittingSize).height ?? 0.0
         var safeAreaBottom: CGFloat = 0.0
         if #available(iOS 11.0, *) {

--- a/Framework/Sources/Info.plist
+++ b/Framework/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Framework/Sources/UIExtensions.swift
+++ b/Framework/Sources/UIExtensions.swift
@@ -74,6 +74,20 @@ extension UIView {
 }
 
 #if __FP_LOG
+#if swift(>=4.2)
+extension UIGestureRecognizer.State: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .began: return "began"
+        case .changed: return "changed"
+        case .failed: return "failed"
+        case .cancelled: return "cancelled"
+        case .ended: return "endeded"
+        case .possible: return "possible"
+        }
+    }
+}
+#else
 extension UIGestureRecognizerState: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
@@ -86,6 +100,7 @@ extension UIGestureRecognizerState: CustomDebugStringConvertible {
         }
     }
 }
+#endif
 #endif
 
 extension UIScrollView {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Platform](https://img.shields.io/cocoapods/p/FloatingPanel.svg)](https://cocoapods.org/pods/FloatingPanel)
 [![Swift 4.1](https://img.shields.io/badge/Swift-4.1-orange.svg?style=flat)](https://swift.org/)
 [![Swift 4.2](https://img.shields.io/badge/Swift-4.2-orange.svg?style=flat)](https://swift.org/)
+[![Swift 5.0](https://img.shields.io/badge/Swift-5.0-orange.svg?style=flat)](https://swift.org/)
 
 #  FloatingPanel
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Examples are here.
 
 ## Requirements
 
-FloatingPanel is written in Swift. It can be built by Xcode 9.4.1 or later. Compatible with iOS 10.0+.
+FloatingPanel is written in Swift 4.0+. It can be built by Xcode 9.4.1 or later. Compatible with iOS 10.0+.
+
+✏️ The default Swift version is 4.0 because it avoids build errors with Carthage on each Xcode version from the source compatibility between Swift 4.0, 4.2 and 5.0.
 
 ## Installation
 
@@ -80,6 +82,8 @@ it, simply add the following line to your Podfile:
 ```ruby
 pod 'FloatingPanel'
 ```
+
+✏️ To suppress "Swift Conversion" warnings in Xcode, please set a Swift version to `SWIFT_VERSION` for the project in your Podfile. It will be resolved in CocoaPods v1.7.0.
 
 ### Carthage
 
@@ -142,7 +146,7 @@ self.present(fpc, animated: true, completion: nil)
 
 You can show a floating panel over UINavigationController from the container view controllers as a modality of `.overCurrentContext` style.
 
-NOTE: FloatingPanelController has the custom presentation controller. If you would like to customize the presentation/dismissal, please see [FloatingPanelTransitioning](https://github.com/SCENEE/FloatingPanel/blob/master/Framework/Sources/FloatingPanelTransitioning.swift).
+✏️ FloatingPanelController has the custom presentation controller. If you would like to customize the presentation/dismissal, please see [FloatingPanelTransitioning](https://github.com/SCENEE/FloatingPanel/blob/master/Framework/Sources/FloatingPanelTransitioning.swift).
 
 ## View hierarchy
 


### PR DESCRIPTION
It's time for FloatingPanel to support both of Swift 5 and Swift 4.x.  
The default Swift version becomes 5.0, but the library still supports Swift 4.0/4.1.

I'm sorry I could have supported both of 4.2 and 4.0/4.1 earlier according to #117.
But after this PR you won't bother Xcode warnings about migration to Swift 4.2 or 5.0.

This PR is planning to be released in v1.5.0.