### PR TITLE
Fix a touch abort on the interaction interrupted

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -38,7 +38,14 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     let panGestureRecognizer: FloatingPanelPanGestureRecognizer
     var isRemovalInteractionEnabled: Bool = false
 
-    fileprivate var animator: UIViewPropertyAnimator?
+    fileprivate var animator: UIViewPropertyAnimator? {
+        didSet { 
+            // This prevents an unexpected UIScrollViewDelayedTouchesBeganGestureRecognizer
+            // failed as possible because it cauese tableView(_:didSelectRowAt:)
+            // not being called on first tap after an animation.
+            scrollView?.isUserInteractionEnabled = (animator == nil)
+        }
+    }
 
     private var initialFrame: CGRect = .zero
     private var initialTranslationY: CGFloat = 0
@@ -302,7 +309,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 // Prevent aborting the touch events when the animator is
                 // released almost at a target position. Because user expect to
                 // enable tap gestures at that position.
-                if fabs(surfaceView.frame.minY - layoutAdapter.topY) > 20.0 {
+                if fabs(surfaceView.frame.minY - layoutAdapter.topY) > 40.0 {
                     if animator.isInterruptible {
                         animator.stopAnimation(false)
                         animator.finishAnimation(at: .current)
@@ -640,6 +647,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     private func finishAnimation(at targetPosition: FloatingPanelPosition) {
         log.debug("finishAnimation to \(targetPosition)")
+
         self.isDecelerating = false
         self.animator = nil
 

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -299,15 +299,19 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
             if let animator = self.animator {
                 log.debug("panel animation interrupted!!!")
-                if animator.isInterruptible {
-                    animator.stopAnimation(false)
-                    animator.finishAnimation(at: .current)
+                // Prevent aborting the touch events when the animator is
+                // released almost at a target position. Because user expect to
+                // enable tap gestures at that position.
+                if fabs(surfaceView.frame.minY - layoutAdapter.topY) > 20.0 {
+                    if animator.isInterruptible {
+                        animator.stopAnimation(false)
+                        animator.finishAnimation(at: .current)
+                    }
+                    self.animator = nil
                 }
 
-                self.animator = nil
-
                 // A user can stop a panel at the nearest Y of a target position
-                if abs(surfaceView.frame.minY - layoutAdapter.topY) < 1 {
+                if abs(surfaceView.frame.minY - layoutAdapter.topY) < 1.0 {
                     surfaceView.frame.origin.y = layoutAdapter.topY
                 }
             }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -40,8 +40,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     fileprivate var animator: UIViewPropertyAnimator? {
         didSet { 
-            // This prevents an unexpected UIScrollViewDelayedTouchesBeganGestureRecognizer
-            // failed as possible because it cauese tableView(_:didSelectRowAt:)
+            // This prevents an unexpected `UIScrollViewDelayedTouchesBeganGestureRecognizer`
+            // failed as possible because it causes `tableView(_:didSelectRowAt:)`
             // not being called on first tap after an animation.
             scrollView?.isUserInteractionEnabled = (animator == nil)
         }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -39,10 +39,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     var isRemovalInteractionEnabled: Bool = false
 
     fileprivate var animator: UIViewPropertyAnimator? {
-        didSet { 
-            // This prevents an unexpected `UIScrollViewDelayedTouchesBeganGestureRecognizer`
-            // failed as possible because it causes `tableView(_:didSelectRowAt:)`
-            // not being called on first tap after an animation.
+        didSet {
+            // This intends to avoid `tableView(_:didSelectRowAt:)` not being
+            // called on first tap after the moving animation, but it doesn't
+            // seem to be enough. The same issue happens on Apple Maps so it
+            // might be an issue in `UITableView`.
             scrollView?.isUserInteractionEnabled = (animator == nil)
         }
     }
@@ -306,9 +307,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
             if let animator = self.animator {
                 log.debug("panel animation interrupted!!!")
-                // Prevent aborting the touch events when the animator is
-                // released almost at a target position. Because user expect to
-                // enable tap gestures at that position.
+                // Prevent aborting touch events when the current animator is
+                // released almost at a target position. Because any tap gestures
+                // shouldn't be disturbed at the position.
                 if fabs(surfaceView.frame.minY - layoutAdapter.topY) > 40.0 {
                     if animator.isInterruptible {
                         animator.stopAnimation(false)


### PR DESCRIPTION
Because touch events seem to be cancelled when an animator is released.

Ref #164 