### PR TITLE
Fix surface mask

### DIFF
--- a/FloatingPanel.podspec
+++ b/FloatingPanel.podspec
@@ -14,7 +14,7 @@ The new interface displays the related contents and utilities in parallel as a u
   s.source              = { :git => "https://github.com/SCENEE/FloatingPanel.git", :tag => "v#{s.version}" }
   s.source_files        = "Framework/Sources/*.swift"
   s.swift_version       = "4.0"
-  s.pod_target_xcconfig = { 'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES', 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+  s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 
   s.framework           = "UIKit"
 

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -117,9 +117,7 @@ public class FloatingPanelSurfaceView: UIView {
 
         updateLayers()
         updateContentViewMask()
-
-        backgroundView.layer.borderColor = borderColor?.cgColor
-        backgroundView.layer.borderWidth = borderWidth
+        updateBorder()
 
         contentView?.frame = bounds
     }
@@ -157,6 +155,11 @@ public class FloatingPanelSurfaceView: UIView {
             // Don't use `contentView.layer.mask` because of a UIVisualEffectView issue in iOS 10, https://forums.developer.apple.com/thread/50854
             // Instead, a user can mask the content view manually in an application.
         }
+    }
+
+    private func updateBorder() {
+        backgroundView.layer.borderColor = borderColor?.cgColor
+        backgroundView.layer.borderWidth = borderWidth
     }
 
     func add(contentView: UIView) {

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -62,9 +62,10 @@ public class FloatingPanelSurfaceView: UIView {
 
     /// The view presents an actual surface shape.
     ///
-    /// It renders the specified background color, border line, and top rounded
-    /// masking a content view by other propertiea. The reason why they don't
-    /// apply to a content view directly is to avoid any side-effects.
+    /// It renders the background color, border line and top rounded corners,
+    /// specified by other properties. The reason why they're not be applied to
+    /// a content view directly is because it avoids any side-effects to the
+    /// content view.
     public var containerView: UIView!
 
     @available(*, unavailable, renamed: "containerView")

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -59,7 +59,14 @@ public class FloatingPanelSurfaceView: UIView {
     /// The color of the surface border.
     public var borderWidth: CGFloat = 0.0  { didSet { setNeedsLayout() } }
 
+
+    /// The view presents an actual surface shape.
+    ///
+    /// It renders a background color, border line, and top rounded masking
+    /// a content view specified by other propertiea. The reason why they don't
+    /// apply to a content view directly is to avoid any side-effects.
     public var backgroundView: UIView!
+
     private var backgroundHeightConstraint: NSLayoutConstraint!
 
     private struct Default {

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -62,12 +62,15 @@ public class FloatingPanelSurfaceView: UIView {
 
     /// The view presents an actual surface shape.
     ///
-    /// It renders a background color, border line, and top rounded masking
-    /// a content view specified by other propertiea. The reason why they don't
+    /// It renders the specified background color, border line, and top rounded
+    /// masking a content view by other propertiea. The reason why they don't
     /// apply to a content view directly is to avoid any side-effects.
+    public var containerView: UIView!
+
+    @available(*, unavailable, renamed: "containerView")
     public var backgroundView: UIView!
 
-    private var backgroundHeightConstraint: NSLayoutConstraint!
+    private var containerViewHeightConstraint: NSLayoutConstraint!
 
     private struct Default {
         public static let grabberTopPadding: CGFloat = 6.0
@@ -89,15 +92,15 @@ public class FloatingPanelSurfaceView: UIView {
 
         let backgroundView = UIView()
         addSubview(backgroundView)
-        self.backgroundView = backgroundView
+        self.containerView = backgroundView
 
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
-        backgroundHeightConstraint = backgroundView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
+        containerViewHeightConstraint = backgroundView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
         NSLayoutConstraint.activate([
             backgroundView.topAnchor.constraint(equalTo: topAnchor, constant: 0.0),
             backgroundView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0.0),
             backgroundView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0.0),
-            backgroundHeightConstraint,
+            containerViewHeightConstraint,
             ])
 
         let grabberHandle = GrabberHandleView()
@@ -115,7 +118,7 @@ public class FloatingPanelSurfaceView: UIView {
 
     public override func updateConstraints() {
         super.updateConstraints()
-        backgroundHeightConstraint.constant = bottomOverflow
+        containerViewHeightConstraint.constant = bottomOverflow
     }
 
     public override func layoutSubviews() {
@@ -130,11 +133,11 @@ public class FloatingPanelSurfaceView: UIView {
     }
 
     private func updateLayers() {
-        backgroundView.backgroundColor = color
+        containerView.backgroundColor = color
 
-        if cornerRadius != 0.0, backgroundView.layer.cornerRadius != cornerRadius {
-            backgroundView.layer.masksToBounds = true
-            backgroundView.layer.cornerRadius = cornerRadius
+        if cornerRadius != 0.0, containerView.layer.cornerRadius != cornerRadius {
+            containerView.layer.masksToBounds = true
+            containerView.layer.cornerRadius = cornerRadius
         }
 
         if shadowHidden == false {
@@ -148,16 +151,16 @@ public class FloatingPanelSurfaceView: UIView {
     private func updateContentViewMask() {
         guard
             cornerRadius != 0.0,
-            backgroundView.layer.cornerRadius != cornerRadius
+            containerView.layer.cornerRadius != cornerRadius
             else { return }
 
         if #available(iOS 11, *) {
             // Don't use `contentView.clipToBounds` because it prevents content view from expanding the height of a subview of it
             // for the bottom overflow like Auto Layout settings of UIVisualEffectView in Main.storyboard of Example/Maps.
             // Because the bottom of contentView must be fit to the bottom of a screen to work the `safeLayoutGuide` of a content VC.
-            backgroundView.layer.masksToBounds = true
-            backgroundView.layer.cornerRadius = cornerRadius
-            backgroundView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+            containerView.layer.masksToBounds = true
+            containerView.layer.cornerRadius = cornerRadius
+            containerView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         } else {
             // Don't use `contentView.layer.mask` because of a UIVisualEffectView issue in iOS 10, https://forums.developer.apple.com/thread/50854
             // Instead, a user can mask the content view manually in an application.
@@ -165,12 +168,12 @@ public class FloatingPanelSurfaceView: UIView {
     }
 
     private func updateBorder() {
-        backgroundView.layer.borderColor = borderColor?.cgColor
-        backgroundView.layer.borderWidth = borderWidth
+        containerView.layer.borderColor = borderColor?.cgColor
+        containerView.layer.borderWidth = borderWidth
     }
 
     func add(contentView: UIView) {
-        backgroundView.addSubview(contentView)
+        containerView.addSubview(contentView)
         self.contentView = contentView
         /* contentView.frame = bounds */ // MUST NOT: Because the top safe area inset of a content VC will be incorrect.
         contentView.translatesAutoresizingMaskIntoConstraints = false

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -91,16 +91,16 @@ public class FloatingPanelSurfaceView: UIView {
         super.backgroundColor = .clear
         self.clipsToBounds = false
 
-        let backgroundView = UIView()
-        addSubview(backgroundView)
-        self.containerView = backgroundView
+        let containerView = UIView()
+        addSubview(containerView)
+        self.containerView = containerView
 
-        backgroundView.translatesAutoresizingMaskIntoConstraints = false
-        containerViewHeightConstraint = backgroundView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerViewHeightConstraint = containerView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
         NSLayoutConstraint.activate([
-            backgroundView.topAnchor.constraint(equalTo: topAnchor, constant: 0.0),
-            backgroundView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0.0),
-            backgroundView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0.0),
+            containerView.topAnchor.constraint(equalTo: topAnchor, constant: 0.0),
+            containerView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0.0),
+            containerView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0.0),
             containerViewHeightConstraint,
             ])
 

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -93,7 +93,6 @@ public class FloatingPanelSurfaceView: UIView {
             backgroundHeightConstraint,
             ])
 
-
         let grabberHandle = GrabberHandleView()
         addSubview(grabberHandle)
         self.grabberHandle = grabberHandle
@@ -119,8 +118,9 @@ public class FloatingPanelSurfaceView: UIView {
         updateLayers()
         updateContentViewMask()
 
-        contentView?.layer.borderColor = borderColor?.cgColor
-        contentView?.layer.borderWidth = borderWidth
+        backgroundView.layer.borderColor = borderColor?.cgColor
+        backgroundView.layer.borderWidth = borderWidth
+
         contentView?.frame = bounds
     }
 
@@ -142,18 +142,17 @@ public class FloatingPanelSurfaceView: UIView {
 
     private func updateContentViewMask() {
         guard
-            let contentView = contentView,
             cornerRadius != 0.0,
-            contentView.layer.cornerRadius != cornerRadius
+            backgroundView.layer.cornerRadius != cornerRadius
             else { return }
 
         if #available(iOS 11, *) {
             // Don't use `contentView.clipToBounds` because it prevents content view from expanding the height of a subview of it
             // for the bottom overflow like Auto Layout settings of UIVisualEffectView in Main.storyboard of Example/Maps.
             // Because the bottom of contentView must be fit to the bottom of a screen to work the `safeLayoutGuide` of a content VC.
-            contentView.layer.masksToBounds = true
-            contentView.layer.cornerRadius = cornerRadius
-            contentView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+            backgroundView.layer.masksToBounds = true
+            backgroundView.layer.cornerRadius = cornerRadius
+            backgroundView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         } else {
             // Don't use `contentView.layer.mask` because of a UIVisualEffectView issue in iOS 10, https://forums.developer.apple.com/thread/50854
             // Instead, a user can mask the content view manually in an application.
@@ -161,7 +160,7 @@ public class FloatingPanelSurfaceView: UIView {
     }
 
     func add(contentView: UIView) {
-        insertSubview(contentView, belowSubview: grabberHandle)
+        backgroundView.addSubview(contentView)
         self.contentView = contentView
         /* contentView.frame = bounds */ // MUST NOT: Because the top safe area inset of a content VC will be incorrect.
         contentView.translatesAutoresizingMaskIntoConstraints = false
@@ -169,7 +168,7 @@ public class FloatingPanelSurfaceView: UIView {
             contentView.topAnchor.constraint(equalTo: topAnchor, constant: 0.0),
             contentView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0.0),
             contentView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0.0),
-            contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0.0),
+            contentView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
             ])
     }
 }

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can show a floating panel over UINavigationController from the container vie
 FloatingPanelController.view (FloatingPanelPassThroughView)
  ├─ .backdropView (FloatingPanelBackdropView)
  └─ .surfaceView (FloatingPanelSurfaceView)
-    ├─ .backgroundView (UIView)
+    ├─ .containerView (UIView)
     │  └─ .contentView (FloatingPanelController.contentViewController.view)
     └─ .grabberHandle (GrabberHandleView)
 ```

--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ You can show a floating panel over UINavigationController from the container vie
 FloatingPanelController.view (FloatingPanelPassThroughView)
  ├─ .backdropView (FloatingPanelBackdropView)
  └─ .surfaceView (FloatingPanelSurfaceView)
-          ├─ .contentView  == FloatingPanelController.contentViewController.view
-          └─ .grabberHandle (GrabberHandleView)
+    ├─ .backgroundView (UIView)
+    │  └─ .contentView (FloatingPanelController.contentViewController.view)
+    └─ .grabberHandle (GrabberHandleView)
 ```
 
 ## Usage


### PR DESCRIPTION
- Fix masking a content view unexpectedly after v1.4.0.
- Also fix #109 probably because now a content view's border isn't changed.