### PR TITLE
Allow to disable tap on backdrop view for panel dismissal

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -88,6 +88,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
 
         // Set tap-to-dismiss in the backdrop view
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
+        tapGesture.isEnabled = false
         backdropView.dismissalTapGestureRecognizer = tapGesture
         backdropView.addGestureRecognizer(tapGesture)
     }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -88,6 +88,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
 
         // Set tap-to-dismiss in the backdrop view
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
+        backdropView.dismissalTapGestureRecognizer = tapGesture
         backdropView.addGestureRecognizer(tapGesture)
     }
 
@@ -261,9 +262,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
     // MARK: - Gesture handling
 
     @objc func handleBackdrop(tapGesture: UITapGestureRecognizer) {
-        if viewcontroller.isTapToDismissEnabled {
-            viewcontroller.dismiss(animated: true, completion: nil)
-        }
+        viewcontroller?.dismiss(animated: true, completion: nil)
     }
 
     @objc func handle(panGesture: UIPanGestureRecognizer) {

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -85,6 +85,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
         surfaceView.addGestureRecognizer(panGestureRecognizer)
         panGestureRecognizer.addTarget(self, action: #selector(handle(panGesture:)))
         panGestureRecognizer.delegate = self
+
+        // Set tap-to-dismiss in the backdrop view
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
+        backdropView.addGestureRecognizer(tapGesture)
     }
 
     func move(to: FloatingPanelPosition, animated: Bool, completion: (() -> Void)? = nil) {
@@ -255,6 +259,13 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
     }
 
     // MARK: - Gesture handling
+
+    @objc func handleBackdrop(tapGesture: UITapGestureRecognizer) {
+        if viewcontroller.isTapToDismissEnabled {
+            viewcontroller.dismiss(animated: true, completion: nil)
+        }
+    }
+
     @objc func handle(panGesture: UIPanGestureRecognizer) {
         let velocity = panGesture.velocity(in: panGesture.view)
 

--- a/Framework/Sources/FloatingPanelBackdropView.swift
+++ b/Framework/Sources/FloatingPanelBackdropView.swift
@@ -6,4 +6,6 @@
 import UIKit
 
 /// A view that presents a backdrop interface behind a floating panel.
-public class FloatingPanelBackdropView: UIView { }
+public class FloatingPanelBackdropView: UIView {
+    public var dismissalTapGestureRecognizer: UITapGestureRecognizer!
+}

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -172,6 +172,9 @@ open class FloatingPanelController: UIViewController, UIScrollViewDelegate, UIGe
         get { return floatingPanel.isRemovalInteractionEnabled }
     }
 
+    /// A Boolean value that determines whether the tap to dismiss interaction is enabled.
+    public var isTapToDismissEnabled: Bool = true
+
     /// The view controller responsible for the content portion of the floating panel.
     public var contentViewController: UIViewController? {
         set { set(contentViewController: newValue) }

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -172,9 +172,6 @@ open class FloatingPanelController: UIViewController, UIScrollViewDelegate, UIGe
         get { return floatingPanel.isRemovalInteractionEnabled }
     }
 
-    /// A Boolean value that determines whether the tap to dismiss interaction is enabled.
-    public var isTapToDismissEnabled: Bool = true
-
     /// The view controller responsible for the content portion of the floating panel.
     public var contentViewController: UIViewController? {
         set { set(contentViewController: newValue) }

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -58,16 +58,6 @@ class FloatingPanelPresentationController: UIPresentationController {
 
         // Forward touch events to the presenting view controller
         (fpc.view as? FloatingPanelPassThroughView)?.eventForwardingView = presentingViewController.view
-
-        if fpc.isTapToDismissEnabled {
-            // Set tap-to-dismiss in the backdrop view
-            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
-            fpc.backdropView.addGestureRecognizer(tapGesture)
-        }
-    }
-
-    @objc func handleBackdrop(tapGesture: UITapGestureRecognizer) {
-        presentedViewController.dismiss(animated: true, completion: nil)
     }
 
     private func addFloatingPanel() {

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -59,9 +59,11 @@ class FloatingPanelPresentationController: UIPresentationController {
         // Forward touch events to the presenting view controller
         (fpc.view as? FloatingPanelPassThroughView)?.eventForwardingView = presentingViewController.view
 
-        // Set tap-to-dismiss in the backdrop view
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
-        fpc.backdropView.addGestureRecognizer(tapGesture)
+        if fpc.isTapToDismissEnabled {
+            // Set tap-to-dismiss in the backdrop view
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
+            fpc.backdropView.addGestureRecognizer(tapGesture)
+        }
     }
 
     @objc func handleBackdrop(tapGesture: UITapGestureRecognizer) {

--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -58,6 +58,12 @@ class FloatingPanelPresentationController: UIPresentationController {
 
         // Forward touch events to the presenting view controller
         (fpc.view as? FloatingPanelPassThroughView)?.eventForwardingView = presentingViewController.view
+
+        fpc.backdropView.dismissalTapGestureRecognizer.isEnabled = true
+    }
+
+    @objc func handleBackdrop(tapGesture: UITapGestureRecognizer) {
+        presentedViewController.dismiss(animated: true, completion: nil)
     }
 
     private func addFloatingPanel() {


### PR DESCRIPTION
I think it would be useful to disable or somehow be able to configure the default tap gesture recognizer for the backdrop view.

Let's say a user of the SDK wants to configure the tap gesture handler (`#selector(handleBackdrop(tapGesture:))` so customize the action triggered when the panel gets dismissed. They can't simply add a gesture recognizer to the backdrop during `FloatingPanelController` configuration, as the default handler is configured later on and effectively overrides the user-provided event handler.

Here is a hack I had to come up to disable the default tap gesture recognizer:

```swift
public extension FloatingPanelBackdropView {
    override func addGestureRecognizer(_ gestureRecognizer: UIGestureRecognizer) {
        // Hack to disable the default tap gesture recognizer since it's added during layout time
        guard gestureRecognizers != nil else {
            return super.addGestureRecognizer(gestureRecognizer)
        }
    }
}
```

I propose to allow the user to disable the default tap gesture recognizer so that they configure their own.
