### PR TITLE
Allow animated FloatingPanelController relayout

### DIFF
--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -516,6 +516,26 @@ open class FloatingPanelController: UIViewController, UIScrollViewDelegate, UIGe
         setUpLayout()
     }
 
+    /// Prepares an update to the layout object from the delegate.
+    ///
+    /// This method must eventually be balanced with a call to endUpdateLayout().
+    /// It can be called in an animation block.
+    public func beginUpdateLayout() {
+        floatingPanel.layoutAdapter.beginUpdateHeight()
+    }
+
+    /// Balances a previous call to beginUpdateLayout(), and updates the layout
+    /// object from the delegate and lays out the views managed by the
+    /// controller immediately.
+    ///
+    /// This method updates the `FloatingPanelLayout` object from the delegate and
+    /// then it calls `layoutIfNeeded()` of the root view to force the view
+    /// to update the floating panel's layout immediately. It can be called in an
+    /// animation block.
+    public func endUpdateLayout() {
+        updateLayout()
+    }
+
     /// Returns the y-coordinate of the point at the origin of the surface view.
     public func originYOfSurface(for pos: FloatingPanelPosition) -> CGFloat {
         switch pos {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -412,6 +412,26 @@ class FloatingPanelLayoutAdapter {
         }
     }
 
+    // Support for FloatingPanelController.beginUpdateLayout/endUpdateLayout.
+    //
+    /// This method must eventually be balanced with a call to updateHeight().
+    func beginUpdateHeight() {
+        guard vc != nil else { return }
+
+        // Deactivate the hard height constraint until updateHeight()
+        if let const = self.heightConstraint {
+            NSLayoutConstraint.deactivate([const])
+        }
+
+        // Activate a very weak temporary height constraint which makes sure the
+        // surface view is not totally free-form.
+        let heightConstraint = surfaceView.heightAnchor.constraint(equalToConstant: 0)
+        heightConstraint.priority = UILayoutPriority(1)
+
+        NSLayoutConstraint.activate([heightConstraint])
+        self.heightConstraint = heightConstraint
+    }
+
     func updateInteractiveTopConstraint(diff: CGFloat, allowsTopBuffer: Bool) {
         defer {
             surfaceView.superview!.layoutIfNeeded() // MUST call here to update `surfaceView.frame`


### PR DESCRIPTION
Hello,

This PR introduces two new methods on FloatingPanelController: beginUpdateLayout(), and endUpdateLayout(). They extend the existing updateLayout() method, and allow applications to transition from one layout to another without facing undesired "Unable to simultaneously satisfy constraints" errors.

My understanding is that those errors happen when the parent controller of the panel wants to change height, because of conflicts with the hard FloatingPanelLayoutAdapter.heightConstraint.

For example, this happens when the panel is embedded in a VC which is not always fullscreen.

This PR lets the host application play a three-steps game:

1. Remove the hard FloatingPanelLayoutAdapter.heightConstraint constraint.
2. Perform custom relayout, without error.
3. Reset the floating panel layout with an updated FloatingPanelLayoutAdapter.heightConstraint.

Usage:

```swift
func updateHeightOfPanelParent() {
    // Begin panel update
    self.panel.beginUpdateLayout()
    
    UIView.animate(withDuration: 0.25, animations: {
        // Change layout of panel's parent
        ...
        // End panel update
        self.panel.endUpdateLayout()
    })
}
```

This PR may also fix #160, but I'm not sure.