### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "FloatingPanel",
+    platforms: [
+        .iOS(.v10)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -19,9 +22,6 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "FloatingPanel", path: "Framework/Sources"),
-    ],
-    platforms: [
-        .iOS(.v10)
     ],
     swiftLanguageVersions: [.version("5")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -19,5 +19,6 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "FloatingPanel", path: "Framework/Sources"),
-    ]
+    ],
+    swiftLanguageVersions: [.version("5")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,6 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "FloatingPanel",
-            path: "Framework/Sources"),
+        .target(name: "FloatingPanel", path: "Framework/Sources"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -20,5 +20,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(name: "FloatingPanel", path: "Framework/Sources"),
     ],
+    platforms: [
+        .iOS(.v10)
+    ],
     swiftLanguageVersions: [.version("5")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "FloatingPanel",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "FloatingPanel",
+            targets: ["FloatingPanel"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "FloatingPanel",
+            path: "Framework/Sources"),
+    ]
+)


### PR DESCRIPTION
Now that Xcode 11 supports SPM natively, I figured it was a good time to submit a Package.swift so that others can use SPM to install FloatingPanel. I've tested this in my project and its working fine.