### PR TITLE
Remove workaround for tableView(_:didSelectRowAt:) issue

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -36,15 +36,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     let panGestureRecognizer: FloatingPanelPanGestureRecognizer
     var isRemovalInteractionEnabled: Bool = false
 
-    fileprivate var animator: UIViewPropertyAnimator? {
-        didSet {
-            // This intends to avoid `tableView(_:didSelectRowAt:)` not being
-            // called on first tap after the moving animation, but it doesn't
-            // seem to be enough. The same issue happens on Apple Maps so it
-            // might be an issue in `UITableView`.
-            scrollView?.isUserInteractionEnabled = (animator == nil)
-        }
-    }
+    fileprivate var animator: UIViewPropertyAnimator?
 
     private var initialFrame: CGRect = .zero
     private var initialTranslationY: CGFloat = 0


### PR DESCRIPTION
The workaround was added to avoid `tableView(_:didSelectRowAt:)` not
being called on first tap after the moving animation. However, it
doesn't only resolved the issue, but also has side effects.

For example, it affects the seamless scrolling in dragging up a panel from
half to full after bouncing it in the bottom buffer. The problem occurs
on "Tab2" sample of "Show Tab Bar".

Moreover the UITableView issue seems to be relieved on iOS 13.

Therefore I remove the workaround.