### PR TITLE
Fix hidden position and animation interruption

### DIFF
--- a/Framework/FloatingPanel.xcodeproj/project.pbxproj
+++ b/Framework/FloatingPanel.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		187BDD94CC9516F88359B26D /* Pods_FloatingPanelTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36D1E7F7D09B093158DE7DBC /* Pods_FloatingPanelTests.framework */; };
 		542753C622C49A6E00D17955 /* FloatingPanelLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542753C522C49A6E00D17955 /* FloatingPanelLayoutTests.swift */; };
 		542753C822C49A8F00D17955 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542753C722C49A8F00D17955 /* Utils.swift */; };
 		54352E9621A51A2500CBCA08 /* FloatingPanelTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54352E9521A51A2500CBCA08 /* FloatingPanelTransitioning.swift */; };

--- a/Framework/FloatingPanel.xcodeproj/project.pbxproj
+++ b/Framework/FloatingPanel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		187BDD94CC9516F88359B26D /* Pods_FloatingPanelTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36D1E7F7D09B093158DE7DBC /* Pods_FloatingPanelTests.framework */; };
 		542753C622C49A6E00D17955 /* FloatingPanelLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542753C522C49A6E00D17955 /* FloatingPanelLayoutTests.swift */; };
 		542753C822C49A8F00D17955 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542753C722C49A8F00D17955 /* Utils.swift */; };
 		54352E9621A51A2500CBCA08 /* FloatingPanelTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54352E9521A51A2500CBCA08 /* FloatingPanelTransitioning.swift */; };
@@ -18,6 +19,7 @@
 		545DB9DE215118C800CA77B8 /* UIExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545DB9DD215118C800CA77B8 /* UIExtensions.swift */; };
 		545DB9E021511AC100CA77B8 /* FloatingPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545DB9DF21511AC100CA77B8 /* FloatingPanelController.swift */; };
 		545DBA2B2152383100CA77B8 /* GrabberHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 545DBA2A2152383100CA77B8 /* GrabberHandleView.swift */; };
+		549E944522CF295D0050AECF /* FloatingPanelPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549E944422CF295D0050AECF /* FloatingPanelPositionTests.swift */; };
 		54A6B6B122968B530077F348 /* FloatingPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A6B6B022968B530077F348 /* FloatingPanelTests.swift */; };
 		54A6B6B622968F710077F348 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 54A6B6B522968F710077F348 /* LaunchScreen.storyboard */; };
 		54A6B6B82296A8520077F348 /* FloatingPanelSurfaceViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A6B6B72296A8520077F348 /* FloatingPanelSurfaceViewTests.swift */; };
@@ -61,6 +63,7 @@
 		545DB9DD215118C800CA77B8 /* UIExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIExtensions.swift; sourceTree = "<group>"; };
 		545DB9DF21511AC100CA77B8 /* FloatingPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelController.swift; sourceTree = "<group>"; };
 		545DBA2A2152383100CA77B8 /* GrabberHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrabberHandleView.swift; sourceTree = "<group>"; };
+		549E944422CF295D0050AECF /* FloatingPanelPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelPositionTests.swift; sourceTree = "<group>"; };
 		54A6B6B022968B530077F348 /* FloatingPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelTests.swift; sourceTree = "<group>"; };
 		54A6B6B522968F710077F348 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		54A6B6B72296A8520077F348 /* FloatingPanelSurfaceViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelSurfaceViewTests.swift; sourceTree = "<group>"; };
@@ -144,9 +147,10 @@
 			isa = PBXGroup;
 			children = (
 				54A6B6B022968B530077F348 /* FloatingPanelTests.swift */,
+				545DB9CF2151169500CA77B8 /* FloatingPanelControllerTests.swift */,
 				542753C522C49A6E00D17955 /* FloatingPanelLayoutTests.swift */,
 				54A6B6B72296A8520077F348 /* FloatingPanelSurfaceViewTests.swift */,
-				545DB9CF2151169500CA77B8 /* FloatingPanelControllerTests.swift */,
+				549E944422CF295D0050AECF /* FloatingPanelPositionTests.swift */,
 				542753C722C49A8F00D17955 /* Utils.swift */,
 				545DB9D12151169500CA77B8 /* Info.plist */,
 			);
@@ -325,6 +329,7 @@
 			files = (
 				54A6B6B122968B530077F348 /* FloatingPanelTests.swift in Sources */,
 				545DB9D02151169500CA77B8 /* FloatingPanelControllerTests.swift in Sources */,
+				549E944522CF295D0050AECF /* FloatingPanelPositionTests.swift in Sources */,
 				542753C622C49A6E00D17955 /* FloatingPanelLayoutTests.swift in Sources */,
 				54A6B6B82296A8520077F348 /* FloatingPanelSurfaceViewTests.swift in Sources */,
 			);

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -321,7 +321,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
                 log.debug("panel animation interrupted!!!")
 
                 animator.stopAnimation(false)
-                // A user can stop a panel at the nearest Y of a target position
+                // A user can stop a panel at the nearest Y of a target position so this fine-tunes
+                // the a small gap between the presentation layer frame and model layer frame
+                // to unlock scroll view properly at finishAnimation(at:)
                 if abs(surfaceView.frame.minY - layoutAdapter.topY) <= 1.0 {
                     surfaceView.frame.origin.y = layoutAdapter.topY
                 }
@@ -685,7 +687,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
         }
 
         stopScrollDeceleration = false
-        // Don't unlock scroll view in animating view when presentation layer != model layer
+
         if state == layoutAdapter.topMostState, surfaceView.frame.minY == layoutAdapter.topY {
             unlockScrollView()
         }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -89,6 +89,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
     }
 
     private func move(from: FloatingPanelPosition, to: FloatingPanelPosition, animated: Bool, completion: (() -> Void)? = nil) {
+        assert(layoutAdapter.isValid(to), "Can't move to '\(to)' position because it's not valid in the layout")
         if state != layoutAdapter.topMostState {
             lockScrollView()
         }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -674,46 +674,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
         return CGFloat(abs(currentY - targetY))
     }
 
-    private func directionalPosition(at currentY: CGFloat, with translation: CGPoint) -> FloatingPanelPosition {
-        return getPosition(at: currentY, with: translation, directional: true)
-    }
-
-    private func redirectionalPosition(at currentY: CGFloat, with translation: CGPoint) -> FloatingPanelPosition {
-        return getPosition(at: currentY, with: translation, directional: false)
-    }
-
-    private func getPosition(at currentY: CGFloat, with translation: CGPoint, directional: Bool) -> FloatingPanelPosition {
-        let supportedPositions: Set = layoutAdapter.supportedPositions
-        if supportedPositions.count == 1 {
-            return state
-        }
-
-        let isForwardYAxis = (translation.y >= 0) == directional
-        let sortedPositions = Array(supportedPositions).sorted(by: { $0.rawValue < $1.rawValue })
-
-        if supportedPositions.count == 2 {
-            return getPosition(from: sortedPositions, with: isForwardYAxis)
-        }
-
-        switch supportedPositions {
-        default:
-            let middleY = layoutAdapter.middleY
-            if currentY > middleY {
-                return (isForwardYAxis) ? .tip : .half
-            } else {
-                return (isForwardYAxis) ? .half : .full
-            }
-        }
-    }
-
-    private func getPosition(from positions: [FloatingPanelPosition], with isForwardYAxis: Bool) -> FloatingPanelPosition {
-        assert(positions.count == 2)
-        let top = positions[0]
-        let bottom = positions[1]
-        assert(top.rawValue < bottom.rawValue)
-        return isForwardYAxis ? bottom : top
-    }
-
     // Distance travelled after decelerating to zero velocity at a constant rate.
     // Refer to the slides p176 of [Designing Fluid Interfaces](https://developer.apple.com/videos/play/wwdc2018/803/)
     private func project(initialVelocity: CGFloat, decelerationRate: CGFloat) -> CGFloat {

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -289,15 +289,15 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
                     scrollView.setContentOffset(initialScrollOffset, animated: false)
                 }
 
-                // Always hide a scroll indicator at the non-top.
+                // Hide a scroll indicator at the non-top in dragging.
                 if interactionInProgress {
                     lockScrollView()
                 }
             } else {
                 let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
-                // Always show a scroll indicator at the top.
+                // Show a scroll indicator at the top in dragging.
                 if interactionInProgress {
-                    if offset > 0 {
+                    if offset >= 0 {
                         unlockScrollView()
                     }
                 } else {

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -524,12 +524,12 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
         endInteraction(for: targetPosition)
 
         if isRemovalInteractionEnabled, isBottomState {
-            let velocityVector = (distance != 0) ? CGVector(dx: 0,
-                                                            dy: min(abs(velocity.y)/distance, behavior.removalVelocity)) : .zero
-
+            let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: min(velocity.y/distance, behavior.removalVelocity)) : .zero
+            // `velocityVector` will be replaced by just a velocity(not vector) when FloatingPanelRemovalInteraction will be added.
             if shouldStartRemovalAnimation(with: velocityVector), let vc = viewcontroller {
                 vc.delegate?.floatingPanelDidEndDraggingToRemove(vc, withVelocity: velocity)
-                startRemovalAnimation(vc, with: velocityVector) { [weak self] in
+                let animationVector = CGVector(dx: abs(velocityVector.dx), dy: abs(velocityVector.dy))
+                startRemovalAnimation(vc, with: animationVector) { [weak self] in
                     self?.finishRemovalAnimation()
                 }
                 return

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -67,14 +67,7 @@ public protocol FloatingPanelBehavior {
 
 public extension FloatingPanelBehavior {
     func shouldProjectMomentum(_ fpc: FloatingPanelController, for proposedTargetPosition: FloatingPanelPosition) -> Bool {
-        switch (fpc.position, proposedTargetPosition) {
-        case (.full, .tip):
-            return false
-        case (.tip,  .full):
-            return false
-        default:
-            return true
-        }
+        return false
     }
 
     func momentumProjectionRate(_ fpc: FloatingPanelController) -> CGFloat {

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -127,7 +127,6 @@ public class FloatingPanelDefaultBehavior: FloatingPanelBehavior {
     public func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
         let timing = timeingCurve(with: velocity)
         let animator = UIViewPropertyAnimator(duration: 0, timingParameters: timing)
-        animator.isInterruptible = false
         return animator
     }
 

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -74,18 +74,32 @@ public enum FloatingPanelPosition: Int {
     }
 
     func next(in positions: [FloatingPanelPosition]) -> FloatingPanelPosition {
+        #if swift(>=4.2)
         guard
             let index = positions.firstIndex(of: self),
             positions.indices.contains(index + 1)
             else { return self }
+        #else
+        guard
+            let index = positions.index(of: self),
+            positions.indices.contains(index + 1)
+            else { return self }
+        #endif
         return positions[index + 1]
     }
 
     func pre(in positions: [FloatingPanelPosition]) -> FloatingPanelPosition {
+        #if swift(>=4.2)
         guard
             let index = positions.firstIndex(of: self),
             positions.indices.contains(index - 1)
             else { return self }
+        #else
+        guard
+            let index = positions.index(of: self),
+            positions.indices.contains(index - 1)
+            else { return self }
+        #endif
         return positions[index - 1]
     }
 }

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -72,6 +72,22 @@ public enum FloatingPanelPosition: Int {
     static var allCases: [FloatingPanelPosition] {
         return [.full, .half, .tip, .hidden]
     }
+
+    func next(in positions: [FloatingPanelPosition]) -> FloatingPanelPosition {
+        guard
+            let index = positions.firstIndex(of: self),
+            positions.indices.contains(index + 1)
+            else { return self }
+        return positions[index + 1]
+    }
+
+    func pre(in positions: [FloatingPanelPosition]) -> FloatingPanelPosition {
+        guard
+            let index = positions.firstIndex(of: self),
+            positions.indices.contains(index - 1)
+            else { return self }
+        return positions[index - 1]
+    }
 }
 
 ///

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -542,16 +542,7 @@ open class FloatingPanelController: UIViewController, UIScrollViewDelegate, UIGe
 
     /// Returns the y-coordinate of the point at the origin of the surface view.
     public func originYOfSurface(for pos: FloatingPanelPosition) -> CGFloat {
-        switch pos {
-        case .full:
-            return floatingPanel.layoutAdapter.topY
-        case .half:
-            return floatingPanel.layoutAdapter.middleY
-        case .tip:
-            return floatingPanel.layoutAdapter.bottomY
-        case .hidden:
-            return floatingPanel.layoutAdapter.hiddenY
-        }
+        return floatingPanel.layoutAdapter.positionY(for: pos)
     }
 }
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -530,9 +530,17 @@ class FloatingPanelLayoutAdapter {
 
         let upperIndex: Int?
         if forward {
+            #if swift(>=4.2)
             upperIndex = sortedPositions.firstIndex(where: { posY < positionY(for: $0) })
+            #else
+            upperIndex = sortedPositions.index(where: { posY < positionY(for: $0) })
+            #endif
         } else {
+            #if swift(>=4.2)
             upperIndex = sortedPositions.firstIndex(where: { posY <= positionY(for: $0) })
+            #else
+            upperIndex = sortedPositions.index(where: { posY <= positionY(for: $0) })
+            #endif
         }
 
         switch upperIndex {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -360,6 +360,7 @@ class FloatingPanelLayoutAdapter {
     }
 
     func startInteraction(at state: FloatingPanelPosition) {
+        guard self.interactiveTopConstraint == nil else { return }
         NSLayoutConstraint.deactivate(fullConstraints + halfConstraints + tipConstraints + offConstraints)
 
         let interactiveTopConstraint: NSLayoutConstraint

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -43,7 +43,7 @@ public protocol FloatingPanelLayout: class {
     /// Returns a set of FloatingPanelPosition objects to tell the applicable
     /// positions of the floating panel controller.
     ///
-    /// By default, it returns all position except for `hidden` position.
+    /// By default, it returns full, half and tip positions.
     var supportedPositions: Set<FloatingPanelPosition> { get }
 
     /// Return the interaction buffer to the top from the top position. Default is 6.0.

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -338,7 +338,7 @@ class FloatingPanelLayoutAdapter {
         ]
     }
 
-    func startInteraction(at state: FloatingPanelPosition) {
+    func startInteraction(at state: FloatingPanelPosition, offset: CGPoint = .zero) {
         guard self.interactiveTopConstraint == nil else { return }
         NSLayoutConstraint.deactivate(fullConstraints + halfConstraints + tipConstraints + offConstraints)
 
@@ -346,11 +346,11 @@ class FloatingPanelLayoutAdapter {
         switch layout {
         case is FloatingPanelIntrinsicLayout,
              is FloatingPanelFullScreenLayout:
-            initialConst = surfaceView.frame.minY
+            initialConst = surfaceView.frame.minY + offset.y
             interactiveTopConstraint = surfaceView.topAnchor.constraint(equalTo: vc.view.topAnchor,
                                                                         constant: initialConst)
         default:
-            initialConst = surfaceView.frame.minY - safeAreaInsets.top
+            initialConst = surfaceView.frame.minY - safeAreaInsets.top + offset.y
             interactiveTopConstraint = surfaceView.topAnchor.constraint(equalTo: vc.layoutGuide.topAnchor,
                                                                         constant: initialConst)
         }

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -190,32 +190,11 @@ class FloatingPanelLayoutAdapter {
     }
 
     var topY: CGFloat {
-        if supportedPositions.contains(.full) {
-            return positionY(for: .full)
-        }
-        if supportedPositions.contains(.half) {
-            return positionY(for: .half)
-        }
-        if supportedPositions.contains(.tip) {
-            return positionY(for: .tip)
-        }
-        return .nan
+        return positionY(for: topMostState)
     }
 
     var bottomY: CGFloat {
-        if supportedPositions.contains(.hidden) {
-            return positionY(for: .hidden)
-        }
-        if supportedPositions.contains(.tip) {
-            return positionY(for: .tip)
-        }
-        if supportedPositions.contains(.half) {
-            return positionY(for: .half)
-        }
-        if supportedPositions.contains(.full) {
-            return positionY(for: .full)
-        }
-        return .nan
+        return positionY(for: bottomMostState)
     }
 
     var topMaxY: CGFloat {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -479,7 +479,7 @@ class FloatingPanelLayoutAdapter {
         }
         NSLayoutConstraint.activate(fixedConstraints)
 
-        if supportedPositions.union([.hidden]).contains(state) == false {
+        if isValid(state) == false {
             state = layout.initialPosition
         }
 
@@ -494,6 +494,10 @@ class FloatingPanelLayoutAdapter {
         case .hidden:
             NSLayoutConstraint.activate(offConstraints)
         }
+    }
+
+    func isValid(_ state: FloatingPanelPosition) -> Bool {
+        return supportedPositions.union([.hidden]).contains(state)
     }
 
     private func setBackdropAlpha(of target: FloatingPanelPosition) {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -202,16 +202,6 @@ class FloatingPanelLayoutAdapter {
         return .nan
     }
 
-    var middleY: CGFloat {
-        if supportedPositions.contains(.half), [topMostState, bottomMostState].contains(.half) == false {
-            return positionY(for: .half)
-        }
-        if supportedPositions.contains(.tip), [topMostState, bottomMostState].contains(.tip) == false  {
-            return positionY(for: .tip)
-        }
-        return .nan
-    }
-
     var bottomY: CGFloat {
         if supportedPositions.contains(.hidden) {
             return positionY(for: .hidden)

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -130,6 +130,10 @@ public class FloatingPanelDefaultLandscapeLayout: FloatingPanelLayout {
     }
 }
 
+struct LayoutSegment {
+    let lower: FloatingPanelPosition?
+    let upper: FloatingPanelPosition?
+}
 
 class FloatingPanelLayoutAdapter {
     weak var vc: UIViewController!
@@ -529,5 +533,31 @@ class FloatingPanelLayoutAdapter {
             assert(middleY > topY, "Invalid insets { topY: \(topY), middleY: \(middleY) }")
             assert(bottomY > topY, "Invalid insets { topY: \(topY), bottomY: \(bottomY) }")
          }*/
+    }
+
+    func segument(at posY: CGFloat, forward: Bool) -> LayoutSegment {
+        /// ----------------------->Y
+        /// --> forward                <-- backward
+        /// |-------|===o===|-------|  |-------|-------|===o===|
+        /// |-------|-------x=======|  |-------|=======x-------|
+        /// |-------|-------|===o===|  |-------|===o===|-------|
+        /// pos: o/x, seguement: =
+        let sortedPositions = supportedPositions.sorted(by: { $0.rawValue < $1.rawValue })
+
+        let upperIndex: Int?
+        if forward {
+            upperIndex = sortedPositions.firstIndex(where: { posY < positionY(for: $0) })
+        } else {
+            upperIndex = sortedPositions.firstIndex(where: { posY <= positionY(for: $0) })
+        }
+
+        switch upperIndex {
+        case 0:
+            return LayoutSegment(lower: nil, upper: sortedPositions.first)
+        case let upperIndex?:
+            return LayoutSegment(lower: sortedPositions[upperIndex - 1], upper: sortedPositions[upperIndex])
+        default:
+            return LayoutSegment(lower: sortedPositions[sortedPositions.endIndex - 1], upper: nil)
+        }
     }
 }

--- a/Framework/Sources/UIExtensions.swift
+++ b/Framework/Sources/UIExtensions.swift
@@ -60,6 +60,10 @@ extension UIView {
             return self
         }
     }
+
+    var presentationFrame: CGRect {
+        return layer.presentation()?.frame ?? frame
+    }
 }
 
 extension UIView {

--- a/Framework/Tests/FloatingPanelControllerTests.swift
+++ b/Framework/Tests/FloatingPanelControllerTests.swift
@@ -107,21 +107,6 @@ class FloatingPanelControllerTests: XCTestCase {
         fpc.move(to: .hidden, animated: false)
         XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .hidden))
     }
-
-    func test_floatingPanelPosition() {
-        var positions: [FloatingPanelPosition]
-        positions = [.full, .half, .tip, .hidden]
-        XCTAssertEqual(FloatingPanelPosition.full.next(in: positions),  .half)
-        XCTAssertEqual(FloatingPanelPosition.full.pre(in: positions),  .full)
-        XCTAssertEqual(FloatingPanelPosition.hidden.next(in: positions), .hidden)
-        XCTAssertEqual(FloatingPanelPosition.hidden.pre(in: positions), .tip)
-
-        positions = [.full, .hidden]
-        XCTAssertEqual(FloatingPanelPosition.full.next(in: positions),  .hidden)
-        XCTAssertEqual(FloatingPanelPosition.full.pre(in: positions),  .full)
-        XCTAssertEqual(FloatingPanelPosition.hidden.next(in: positions), .hidden)
-        XCTAssertEqual(FloatingPanelPosition.hidden.pre(in: positions), .full)
-    }
 }
 
 private class MyZombieViewController: UIViewController, FloatingPanelLayout, FloatingPanelBehavior, FloatingPanelControllerDelegate {

--- a/Framework/Tests/FloatingPanelControllerTests.swift
+++ b/Framework/Tests/FloatingPanelControllerTests.swift
@@ -53,6 +53,47 @@ class FloatingPanelControllerTests: XCTestCase {
         fpc.prepare(for: traitCollection)
     }
 
+    func test_moveTo() {
+        let fpc = FloatingPanelController(delegate: nil)
+        fpc.showForTest()
+        fpc.move(to: .full, animated: false)
+        XCTAssertEqual(fpc.position, .full)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .full))
+
+        fpc.move(to: .half, animated: false)
+        XCTAssertEqual(fpc.position, .half)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .half))
+
+        fpc.move(to: .tip, animated: false)
+        XCTAssertEqual(fpc.position, .tip)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .tip))
+
+        fpc.move(to: .hidden, animated: false)
+        XCTAssertEqual(fpc.position, .hidden)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .hidden))
+
+        fpc.move(to: .full, animated: true)
+        waitRunLoop(secs: 0.3)
+        XCTAssertEqual(fpc.position, .full)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .full))
+
+        fpc.move(to: .half, animated: true)
+        waitRunLoop(secs: 0.3)
+        XCTAssertEqual(fpc.position, .half)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .half))
+
+        fpc.move(to: .tip, animated: true)
+        waitRunLoop(secs: 0.3)
+        XCTAssertEqual(fpc.position, .tip)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .tip))
+
+        fpc.move(to: .hidden, animated: true)
+        waitRunLoop(secs: 0.3)
+        XCTAssertEqual(fpc.position, .hidden)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .hidden))
+
+    }
+
     func test_originSurfaceY() {
         let fpc = FloatingPanelController(delegate: nil)
         fpc.loadViewIfNeeded()

--- a/Framework/Tests/FloatingPanelControllerTests.swift
+++ b/Framework/Tests/FloatingPanelControllerTests.swift
@@ -68,6 +68,21 @@ class FloatingPanelControllerTests: XCTestCase {
         fpc.move(to: .hidden, animated: false)
         XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .hidden))
     }
+
+    func test_floatingPanelPosition() {
+        var positions: [FloatingPanelPosition]
+        positions = [.full, .half, .tip, .hidden]
+        XCTAssertEqual(FloatingPanelPosition.full.next(in: positions),  .half)
+        XCTAssertEqual(FloatingPanelPosition.full.pre(in: positions),  nil)
+        XCTAssertEqual(FloatingPanelPosition.hidden.next(in: positions), nil)
+        XCTAssertEqual(FloatingPanelPosition.hidden.pre(in: positions), .tip)
+
+        positions = [.full, .hidden]
+        XCTAssertEqual(FloatingPanelPosition.full.next(in: positions),  .hidden)
+        XCTAssertEqual(FloatingPanelPosition.full.pre(in: positions),  .full)
+        XCTAssertEqual(FloatingPanelPosition.hidden.next(in: positions), .hidden)
+        XCTAssertEqual(FloatingPanelPosition.hidden.pre(in: positions), .full)
+    }
 }
 
 private class MyZombieViewController: UIViewController, FloatingPanelLayout, FloatingPanelBehavior, FloatingPanelControllerDelegate {

--- a/Framework/Tests/FloatingPanelControllerTests.swift
+++ b/Framework/Tests/FloatingPanelControllerTests.swift
@@ -7,9 +7,7 @@ import XCTest
 @testable import FloatingPanel
 
 class FloatingPanelControllerTests: XCTestCase {
-
     override func setUp() {}
-
     override func tearDown() {}
 
     func test_warningRetainCycle() {
@@ -114,8 +112,8 @@ class FloatingPanelControllerTests: XCTestCase {
         var positions: [FloatingPanelPosition]
         positions = [.full, .half, .tip, .hidden]
         XCTAssertEqual(FloatingPanelPosition.full.next(in: positions),  .half)
-        XCTAssertEqual(FloatingPanelPosition.full.pre(in: positions),  nil)
-        XCTAssertEqual(FloatingPanelPosition.hidden.next(in: positions), nil)
+        XCTAssertEqual(FloatingPanelPosition.full.pre(in: positions),  .full)
+        XCTAssertEqual(FloatingPanelPosition.hidden.next(in: positions), .hidden)
         XCTAssertEqual(FloatingPanelPosition.hidden.pre(in: positions), .tip)
 
         positions = [.full, .hidden]

--- a/Framework/Tests/FloatingPanelControllerTests.swift
+++ b/Framework/Tests/FloatingPanelControllerTests.swift
@@ -52,6 +52,22 @@ class FloatingPanelControllerTests: XCTestCase {
         XCTAssertEqual(traitCollection.userInterfaceStyle, .dark)
         fpc.prepare(for: traitCollection)
     }
+
+    func test_originSurfaceY() {
+        let fpc = FloatingPanelController(delegate: nil)
+        fpc.loadViewIfNeeded()
+        fpc.view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
+        fpc.show(animated: false, completion: nil)
+
+        fpc.move(to: .full, animated: false)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .full))
+        fpc.move(to: .half, animated: false)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .half))
+        fpc.move(to: .tip, animated: false)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .tip))
+        fpc.move(to: .hidden, animated: false)
+        XCTAssertEqual(fpc.surfaceView.frame.minY, fpc.originYOfSurface(for: .hidden))
+    }
 }
 
 private class MyZombieViewController: UIViewController, FloatingPanelLayout, FloatingPanelBehavior, FloatingPanelControllerDelegate {

--- a/Framework/Tests/FloatingPanelLayoutTests.swift
+++ b/Framework/Tests/FloatingPanelLayoutTests.swift
@@ -31,7 +31,7 @@ class FloatingPanelLayoutTests: XCTestCase {
         delegate.layout = FloatingPanelLayoutWithHidden()
         fpc.delegate = delegate
         XCTAssertEqual(fpc.floatingPanel.layoutAdapter.topMostState, .full)
-        XCTAssertEqual(fpc.floatingPanel.layoutAdapter.bottomMostState, .half) // Will fixed on fix-hidden-position branch
+        XCTAssertEqual(fpc.floatingPanel.layoutAdapter.bottomMostState, .hidden)
 
         delegate.layout = FloatingPanelLayout2Positions()
         fpc.delegate = delegate

--- a/Framework/Tests/FloatingPanelLayoutTests.swift
+++ b/Framework/Tests/FloatingPanelLayoutTests.swift
@@ -38,4 +38,35 @@ class FloatingPanelLayoutTests: XCTestCase {
         XCTAssertEqual(fpc.floatingPanel.layoutAdapter.topMostState, .half)
         XCTAssertEqual(fpc.floatingPanel.layoutAdapter.bottomMostState, .tip)
     }
+
+    func test_positionSegment() {
+        let fpc = FloatingPanelController(delegate: nil)
+        fpc.loadViewIfNeeded()
+        fpc.view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let halfPos = fpc.originYOfSurface(for: .half)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+
+        var segument: LayoutSegment
+
+        segument = fpc.floatingPanel.layoutAdapter.segument(at: fullPos, forward: true)
+        XCTAssertEqual(segument.lower, .full)
+        XCTAssertEqual(segument.upper, .half)
+        segument = fpc.floatingPanel.layoutAdapter.segument(at: fullPos, forward: false)
+        XCTAssertEqual(segument.lower, nil)
+        XCTAssertEqual(segument.upper, .full)
+        segument = fpc.floatingPanel.layoutAdapter.segument(at: halfPos, forward: true)
+        XCTAssertEqual(segument.lower, .half)
+        XCTAssertEqual(segument.upper, .tip)
+        segument = fpc.floatingPanel.layoutAdapter.segument(at: halfPos, forward: false)
+        XCTAssertEqual(segument.lower, .full)
+        XCTAssertEqual(segument.upper, .half)
+        segument = fpc.floatingPanel.layoutAdapter.segument(at: tipPos, forward: true)
+        XCTAssertEqual(segument.lower, .tip)
+        XCTAssertEqual(segument.upper, nil)
+        segument = fpc.floatingPanel.layoutAdapter.segument(at: tipPos, forward: false)
+        XCTAssertEqual(segument.lower, .half)
+        XCTAssertEqual(segument.upper, .tip)
+    }
 }

--- a/Framework/Tests/FloatingPanelLayoutTests.swift
+++ b/Framework/Tests/FloatingPanelLayoutTests.swift
@@ -7,13 +7,15 @@ import XCTest
 @testable import FloatingPanel
 
 class FloatingPanelLayoutTests: XCTestCase {
-    override func setUp() {}
+    var fpc: FloatingPanelController!
+    override func setUp() {
+        fpc = FloatingPanelController(delegate: nil)
+        fpc.loadViewIfNeeded()
+        fpc.view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
+    }
     override func tearDown() {}
 
     func test_layoutAdapter_topAndBottomMostState() {
-        let fpc = FloatingPanelController(delegate: nil)
-        fpc.loadViewIfNeeded()
-        fpc.view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
         XCTAssertEqual(fpc.floatingPanel.layoutAdapter.topMostState, .full)
         XCTAssertEqual(fpc.floatingPanel.layoutAdapter.bottomMostState, .tip)
 
@@ -40,10 +42,6 @@ class FloatingPanelLayoutTests: XCTestCase {
     }
 
     func test_positionSegment() {
-        let fpc = FloatingPanelController(delegate: nil)
-        fpc.loadViewIfNeeded()
-        fpc.view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
-
         let fullPos = fpc.originYOfSurface(for: .full)
         let halfPos = fpc.originYOfSurface(for: .half)
         let tipPos = fpc.originYOfSurface(for: .tip)
@@ -68,5 +66,75 @@ class FloatingPanelLayoutTests: XCTestCase {
         segument = fpc.floatingPanel.layoutAdapter.segument(at: tipPos, forward: false)
         XCTAssertEqual(segument.lower, .half)
         XCTAssertEqual(segument.upper, .tip)
+    }
+
+    func test_updateInteractiveTopConstraint() {
+        fpc.showForTest()
+        fpc.move(to: .full, animated: false)
+
+        fpc.floatingPanel.layoutAdapter.startInteraction(at: fpc.position)
+        fpc.floatingPanel.layoutAdapter.startInteraction(at: fpc.position) // Should be ignore
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+
+        var pre: CGFloat
+        var next: CGFloat
+        pre = fpc.surfaceView.frame.minY
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: -100.0, allowsTopBuffer: false, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, pre)
+
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: -100.0, allowsTopBuffer: true, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, fullPos - fpc.layout.topInteractionBuffer)
+
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: 100.0, allowsTopBuffer: true, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, fullPos + 100.0)
+
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: tipPos - fullPos, allowsTopBuffer: true, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, tipPos)
+
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: tipPos - fullPos + 100.0, allowsTopBuffer: true, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, tipPos + fpc.layout.bottomInteractionBuffer)
+
+        fpc.floatingPanel.layoutAdapter.endInteraction(at: fpc.position)
+    }
+
+    func test_updateInteractiveTopConstraintWithHidden() {
+        class FloatingPanelLayout2Positions: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .hidden
+            let supportedPositions: Set<FloatingPanelPosition> = [.hidden, .full]
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout2Positions()
+        fpc.delegate = delegate
+        fpc.showForTest()
+        fpc.move(to: .full, animated: false)
+
+        fpc.floatingPanel.layoutAdapter.startInteraction(at: fpc.position)
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let hiddenPos = fpc.originYOfSurface(for: .hidden)
+
+        var pre: CGFloat
+        var next: CGFloat
+        pre = fpc.surfaceView.frame.minY
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: -100.0, allowsTopBuffer: false, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, pre)
+
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: -100.0, allowsTopBuffer: true, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, fullPos - fpc.layout.topInteractionBuffer)
+
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: hiddenPos - fullPos + 100.0, allowsTopBuffer: true, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, hiddenPos + fpc.layout.bottomInteractionBuffer)
+
+        fpc.floatingPanel.layoutAdapter.endInteraction(at: fpc.position)
     }
 }

--- a/Framework/Tests/FloatingPanelPositionTests.swift
+++ b/Framework/Tests/FloatingPanelPositionTests.swift
@@ -1,0 +1,27 @@
+//
+//  Created by Shin Yamamoto on 2019/07/05.
+//  Copyright © 2019 scenee. All rights reserved.
+//
+
+import XCTest
+@testable import FloatingPanel
+
+class FloatingPanelPositionTests: XCTestCase {
+    override func setUp() { }
+    override func tearDown() { }
+
+    func test_nextAndPre() {
+        var positions: [FloatingPanelPosition]
+        positions = [.full, .half, .tip, .hidden]
+        XCTAssertEqual(FloatingPanelPosition.full.next(in: positions),  .half)
+        XCTAssertEqual(FloatingPanelPosition.full.pre(in: positions),  .full)
+        XCTAssertEqual(FloatingPanelPosition.hidden.next(in: positions), .hidden)
+        XCTAssertEqual(FloatingPanelPosition.hidden.pre(in: positions), .tip)
+
+        positions = [.full, .hidden]
+        XCTAssertEqual(FloatingPanelPosition.full.next(in: positions),  .hidden)
+        XCTAssertEqual(FloatingPanelPosition.full.pre(in: positions),  .full)
+        XCTAssertEqual(FloatingPanelPosition.hidden.next(in: positions), .hidden)
+        XCTAssertEqual(FloatingPanelPosition.hidden.pre(in: positions), .full)
+    }
+}

--- a/Framework/Tests/FloatingPanelSurfaceViewTests.swift
+++ b/Framework/Tests/FloatingPanelSurfaceViewTests.swift
@@ -8,7 +8,6 @@ import XCTest
 
 class FloatingPanelSurfaceViewTests: XCTestCase {
     override func setUp() {}
-
     override func tearDown() {}
 
     func test_surfaceView() {

--- a/Framework/Tests/FloatingPanelTests.swift
+++ b/Framework/Tests/FloatingPanelTests.swift
@@ -60,16 +60,375 @@ class FloatingPanelTests: XCTestCase {
         XCTAssertEqual(contentVC2.tableView.bounces, false)
     }
 
+    func test_targetPosition_2positions() {
+        class FloatingPanelLayout2Positions: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .half
+            let supportedPositions: Set<FloatingPanelPosition> = [.half, .full]
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout2Positions()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let halfPos = fpc.originYOfSurface(for: .half)
+
+        fpc.move(to: .full, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 10.0, CGPoint(x: 0.0, y: 1000.0), .half), // project to half
+            (#line, fullPos, CGPoint(x: 0.0, y: -1000.0), .full), // redirect
+            (#line, fullPos, CGPoint(x: 0.0, y: -100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 0.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .half), // project to half
+            (#line, fullPos + 10.0, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            (#line, halfPos - 10.0, CGPoint(x: 0.0, y: -100.0), .half), // redirect
+            (#line, halfPos, CGPoint(x: 0.0, y: -1000.0), .full),  // project to full
+            (#line, halfPos, CGPoint(x: 0.0, y: -100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 0.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 1000.0), .half), // redirect
+            (#line, halfPos + 10.0, CGPoint(x: 0.0, y: -1000.0), .full), // project to full
+            ])
+        fpc.move(to: .half, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 10.0, CGPoint(x: 0.0, y: 1000.0), .half), // project to half
+            (#line, fullPos, CGPoint(x: 0.0, y: -1000.0), .full), // redirect
+            (#line, fullPos, CGPoint(x: 0.0, y: -100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 0.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .half), // project to half
+            (#line, fullPos + 10.0, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            (#line, halfPos - 10.0, CGPoint(x: 0.0, y: -100.0), .half), // redirect
+            (#line, halfPos, CGPoint(x: 0.0, y: -1000.0), .full),  // project to full
+            (#line, halfPos, CGPoint(x: 0.0, y: -100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 0.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 1000.0), .half), // redirect
+            (#line, halfPos + 10.0, CGPoint(x: 0.0, y: -1000.0), .full), // project to full
+            ])
+    }
+
+    func test_targetPosition_2positionsWithHidden() {
+        class FloatingPanelLayout2Positions: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .hidden
+            let supportedPositions: Set<FloatingPanelPosition> = [.hidden, .full]
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout2Positions()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let hiddenPos = fpc.originYOfSurface(for: .hidden)
+
+        fpc.move(to: .full, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 10.0, CGPoint(x: 0.0, y: 1000.0), .hidden), // project to hidden
+            (#line, fullPos, CGPoint(x: 0.0, y: -1000.0), .full), // redirect
+            (#line, fullPos, CGPoint(x: 0.0, y: -100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 0.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .hidden), // project to hidden
+            (#line, fullPos + 10.0, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            (#line, hiddenPos - 10.0, CGPoint(x: 0.0, y: -100.0), .hidden), // redirect
+            (#line, hiddenPos, CGPoint(x: 0.0, y: -1000.0), .full),  // project to full
+            (#line, hiddenPos, CGPoint(x: 0.0, y: -100.0), .hidden),
+            (#line, hiddenPos, CGPoint(x: 0.0, y: 0.0), .hidden),
+            (#line, hiddenPos, CGPoint(x: 0.0, y: 100.0), .hidden),
+            (#line, hiddenPos, CGPoint(x: 0.0, y: 1000.0), .hidden), // redirect
+            (#line, hiddenPos + 10.0, CGPoint(x: 0.0, y: -1000.0), .full), // project to full
+            ])
+        fpc.move(to: .hidden, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 10.0, CGPoint(x: 0.0, y: 1000.0), .hidden), // project to hidden
+            (#line, fullPos, CGPoint(x: 0.0, y: -1000.0), .full), // redirect
+            (#line, fullPos, CGPoint(x: 0.0, y: -100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 0.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .hidden), // project to hidden
+            (#line, fullPos + 10.0, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            (#line, hiddenPos - 10.0, CGPoint(x: 0.0, y: -100.0), .hidden), // redirect
+            (#line, hiddenPos, CGPoint(x: 0.0, y: -1000.0), .full),  // project to full
+            (#line, hiddenPos, CGPoint(x: 0.0, y: -100.0), .hidden),
+            (#line, hiddenPos, CGPoint(x: 0.0, y: 0.0), .hidden),
+            (#line, hiddenPos, CGPoint(x: 0.0, y: 100.0), .hidden),
+            (#line, hiddenPos, CGPoint(x: 0.0, y: 1000.0), .hidden), // redirect
+            (#line, hiddenPos + 10.0, CGPoint(x: 0.0, y: -1000.0), .full), // project to full
+            ])
+    }
+
+    func test_targetPosition_2positionsFromFull() {
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout3Positions()
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let halfPos = fpc.originYOfSurface(for: .half)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+        // From .full
+        fpc.move(to: .full, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: -100.0), .full), // far from topMostState
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: 0.0), .full), // far from topMostState
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: 100.0), .full), // far from topMostState
+            (#line, fullPos - 10.0, CGPoint(x: 0.0, y: 3000.0), .half), // block projecting to tip at half
+            (#line, fullPos, CGPoint(x: 0.0, y: -100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 0.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 500.0), .half), // project to half
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .half), // block projecting to tip at half
+            (#line, fullPos, CGPoint(x: 0.0, y: 3000.0), .half), // block projecting to tip at half
+            (#line, fullPos + 10.0, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            (#line, halfPos - 10.0, CGPoint(x: 0.0, y: -100.0), .half), // redirect
+            (#line, halfPos, CGPoint(x: 0.0, y: -1000.0), .full), //project to full
+            (#line, halfPos, CGPoint(x: 0.0, y: -100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 0.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 1000.0), .tip), // project to tip
+            (#line, halfPos + 10.0, CGPoint(x: 0.0, y: 100.0), .half), // redirect
+            (#line, tipPos - 10.0, CGPoint(x: 0.0, y: -100.0), .tip), // redirect
+            (#line, tipPos, CGPoint(x: 0.0, y: -3000.0), .half), // block projecting to full at half
+            (#line, tipPos, CGPoint(x: 0.0, y: -1000.0), .half), // block projecting to full at half
+            (#line, tipPos, CGPoint(x: 0.0, y: -500.0), .half), // project to half
+            (#line, tipPos, CGPoint(x: 0.0, y: -100.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 0.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 100.0), .tip),
+            (#line, tipPos + 10.0, CGPoint(x: 0.0, y: -3000.0), .half), // block projecting to full at half
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: -100.0), .tip), // far from bottomMostState
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: 0.0), .tip), // far from bottomMostState
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: 100.0), .tip), // far from bottomMostState
+            ])
+    }
+
+    func test_targetPosition_3positionsFromHalf() {
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout3Positions()
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let halfPos = fpc.originYOfSurface(for: .half)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+        // From .half
+        fpc.move(to: .half, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: -100.0), .full), // far from topMostState
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: 0.0), .full), // far from topMostState
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: 100.0), .full), // far from topMostState
+            (#line, fullPos, CGPoint(x: 0.0, y: -100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 0.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 500.0), .half), // project to half
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .half), // block projecting to tip at half
+            (#line, fullPos, CGPoint(x: 0.0, y: 3000.0), .half), // block projecting to tip at half
+            (#line, fullPos + 10.0, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            (#line, halfPos - 10.0, CGPoint(x: 0.0, y: -100.0), .half), // redirect
+            (#line, halfPos, CGPoint(x: 0.0, y: -1000.0), .full),// project to full
+            (#line, halfPos, CGPoint(x: 0.0, y: -100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 0.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 1000.0), .tip), // project to tip
+            (#line, halfPos + 10.0, CGPoint(x: 0.0, y: 100.0), .half), // redirect
+            (#line, tipPos - 10.0, CGPoint(x: 0.0, y: -100.0), .tip), // redirect
+            (#line, tipPos, CGPoint(x: 0.0, y: -3000.0), .half), // block projecting to full at half
+            (#line, tipPos, CGPoint(x: 0.0, y: -1000.0), .half), // block projecting to full at half
+            (#line, tipPos, CGPoint(x: 0.0, y: -500.0), .half), // project to half
+            (#line, tipPos, CGPoint(x: 0.0, y: -100.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 0.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 100.0), .tip),
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: -100.0), .tip), // far from bottomMostState
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: 0.0), .tip), // far from bottomMostState
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: 100.0), .tip), // far from bottomMostState
+            ])
+    }
+
+    func test_targetPosition_3positionsFromTip() {
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout3Positions()
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let halfPos = fpc.originYOfSurface(for: .half)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+
+        // From .tip
+        fpc.move(to: .tip, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: -100.0), .full), // far from topMostState
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: 0.0), .full), // far from topMostState
+            (#line, fullPos - 500.0, CGPoint(x: 0.0, y: 100.0), .full), // far from topMostState
+            (#line, fullPos, CGPoint(x: 0.0, y: -100.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 0.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 500.0), .half), // project to half
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .half), // block projecting to tip at half
+            (#line, fullPos, CGPoint(x: 0.0, y: 3000.0), .half), // block projecting to tip at half
+            (#line, fullPos + 10.0, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            (#line, halfPos - 10.0, CGPoint(x: 0.0, y: -100.0), .half), // redirect
+            (#line, halfPos, CGPoint(x: 0.0, y: -3000.0), .full), // project to full
+            (#line, halfPos, CGPoint(x: 0.0, y: -100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 0.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 1000.0), .tip), // project to tip
+            (#line, halfPos + 10.0, CGPoint(x: 0.0, y: 100.0), .half), // redirect
+            (#line, tipPos - 10.0, CGPoint(x: 0.0, y: -100.0), .tip), // redirect
+            (#line, tipPos, CGPoint(x: 0.0, y: -3000.0), .half), // block projecting to full at half
+            (#line, tipPos, CGPoint(x: 0.0, y: -1000.0), .half), // block projecting to full at half
+            (#line, tipPos, CGPoint(x: 0.0, y: -500.0), .half), // project to half
+            (#line, tipPos, CGPoint(x: 0.0, y: -100.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 0.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 100.0), .tip),
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: -100.0), .tip), // far from bottomMostState
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: 0.0), .tip), // far from bottomMostState
+            (#line, tipPos + 500.0, CGPoint(x: 0.0, y: 100.0), .tip), // far from bottomMostState
+            ])
+    }
+
+    func test_targetPosition_3positionsAllProjection() {
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout3Positions()
+        delegate.behavior = FloatingPanelProjectionalBehavior()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let halfPos = fpc.originYOfSurface(for: .half)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+
+        // From .full
+        fpc.move(to: .full, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 10.0, CGPoint(x: 0.0, y: 3000.0), .tip),
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .tip),
+            (#line, fullPos, CGPoint(x: 0.0, y: 3000.0), .tip),
+            (#line, halfPos, CGPoint(x: 0.0, y: 1000.0), .tip),
+            (#line, halfPos, CGPoint(x: 0.0, y: -1000.0), .full),
+            (#line, tipPos, CGPoint(x: 0.0, y: -3000.0), .full),
+            (#line, tipPos, CGPoint(x: 0.0, y: -1000.0), .full),
+            (#line, tipPos + 10.0, CGPoint(x: 0.0, y: -3000.0), .full),
+            ])
+
+        // From .half
+        fpc.move(to: .tip, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .tip),
+            (#line, fullPos, CGPoint(x: 0.0, y: 3000.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: -3000.0), .full),
+            (#line, tipPos, CGPoint(x: 0.0, y: -1000.0), .full),
+            ])
+
+        // From .tip
+        fpc.move(to: .tip, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 10.0, CGPoint(x: 0.0, y: 3000.0), .tip),
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .tip),
+            (#line, fullPos, CGPoint(x: 0.0, y: 3000.0), .tip),
+            (#line, halfPos, CGPoint(x: 0.0, y: 1000.0), .tip),
+            (#line, halfPos, CGPoint(x: 0.0, y: -1000.0), .full),
+            (#line, tipPos, CGPoint(x: 0.0, y: -3000.0), .full),
+            (#line, tipPos, CGPoint(x: 0.0, y: -1000.0), .full),
+            (#line, tipPos + 10.0, CGPoint(x: 0.0, y: -3000.0), .full),
+            ])
+    }
+
+    func test_targetPosition_3positionsWithHidden() {
+        class FloatingPanelLayout3PositionsWithHidden: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .hidden
+            let supportedPositions: Set<FloatingPanelPosition> = [.hidden, .half, .full]
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout3PositionsWithHidden()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+        XCTAssertEqual(fpc.position, .hidden)
+
+        fpc.move(to: .full, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fpc.surfaceView.frame.minY, CGPoint(x: 0.0, y: 1000.0), .half),
+            ])
+        fpc.move(to: .half, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fpc.surfaceView.frame.minY, CGPoint(x: 0.0, y: -100.0), .half),
+            (#line, fpc.surfaceView.frame.minY, CGPoint(x: 0.0, y: -1000.0), .full),
+            (#line, fpc.surfaceView.frame.minY, CGPoint(x: 0.0, y: 0.0), .half),
+            (#line, fpc.surfaceView.frame.minY, CGPoint(x: 0.0, y: 1000.0), .hidden),
+            ])
+    }
+
+    func test_targetPosition_3positionsWithHiddenWithoutFull() {
+        class FloatingPanelLayout3Positions: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .hidden
+            let supportedPositions: Set<FloatingPanelPosition> = [.hidden, .tip, .half]
+        }
+
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout3Positions()
+        delegate.behavior = FloatingPanelProjectionalBehavior()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+        XCTAssertEqual(fpc.position, .hidden)
+
+        let halfPos = fpc.originYOfSurface(for: .half)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+        //let hiddenPos = fpc.originYOfSurface(for: .hidden)
+
+        fpc.move(to: .half, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, halfPos, CGPoint(x: 0.0, y: -100.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 0.0), .half),
+            (#line, halfPos, CGPoint(x: 0.0, y: 385.0), .tip), // projection
+            (#line, halfPos, CGPoint(x: 0.0, y: 1000.0), .hidden), // projection
+            (#line, halfPos + 10.0, CGPoint(x: 0.0, y: 100.0), .half), // redirection
+            (#line, tipPos - 10.0, CGPoint(x: 0.0, y: -100.0), .tip), // redirection
+            (#line, tipPos, CGPoint(x: 0.0, y: -3000.0), .half), //projection
+            (#line, tipPos, CGPoint(x: 0.0, y: -10.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 0.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 10.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 1000.0), .hidden), //projection
+            (#line, tipPos + 10.0, CGPoint(x: 0.0, y: 10.0), .tip), // redirection
+            (#line, tipPos - 10.0, CGPoint(x: 0.0, y: 10.0), .tip), // redirection
+            ])
+        fpc.move(to: .tip, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, tipPos, CGPoint(x: 0.0, y: -100.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: -1000.0), .half),
+            (#line, tipPos, CGPoint(x: 0.0, y: 0.0), .tip),
+            (#line, tipPos, CGPoint(x: 0.0, y: 1000.0), .hidden),
+            ])
+    }
 }
 
-private protocol FloatingPanelTestLayout: FloatingPanelLayout {}
+private class FloatingPanelLayout3Positions: FloatingPanelTestLayout {
+    let initialPosition: FloatingPanelPosition = .tip
+    let supportedPositions: Set<FloatingPanelPosition> = [.tip, .half, .full]
+}
+
+private typealias TestParameter = (UInt, CGFloat,CGPoint, FloatingPanelPosition)
+private func assertTargetPosition(_ floatingPanel: FloatingPanel, with params: [TestParameter]) {
+    params.forEach { (line, pos, velocity, result) in
+        floatingPanel.surfaceView.frame.origin.y = pos
+        XCTAssertEqual(floatingPanel.targetPosition(from: pos, with: velocity), result, line: line)
+    }
+}
+
+private protocol FloatingPanelTestLayout: FloatingPanelFullScreenLayout {}
 private extension FloatingPanelTestLayout {
     func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
-        case .full: return 18.0
-        case .half: return 262.0
-        case .tip: return 69.0
+        case .full: return 20.0
+        case .half: return 250.0
+        case .tip: return 60.0
         default: return nil
         }
+    }
+}
+private class FloatingPanelProjectionalBehavior: FloatingPanelBehavior {
+    func shouldProjectMomentum(_ fpc: FloatingPanelController, for proposedTargetPosition: FloatingPanelPosition) -> Bool {
+        return true
     }
 }

--- a/Framework/Tests/FloatingPanelTests.swift
+++ b/Framework/Tests/FloatingPanelTests.swift
@@ -530,17 +530,6 @@ private func assertTargetPosition(_ floatingPanel: FloatingPanel, with params: [
     }
 }
 
-private protocol FloatingPanelTestLayout: FloatingPanelFullScreenLayout {}
-private extension FloatingPanelTestLayout {
-    func insetFor(position: FloatingPanelPosition) -> CGFloat? {
-        switch position {
-        case .full: return 20.0
-        case .half: return 250.0
-        case .tip: return 60.0
-        default: return nil
-        }
-    }
-}
 private class FloatingPanelProjectionalBehavior: FloatingPanelBehavior {
     func shouldProjectMomentum(_ fpc: FloatingPanelController, for proposedTargetPosition: FloatingPanelPosition) -> Bool {
         return true

--- a/Framework/Tests/FloatingPanelTests.swift
+++ b/Framework/Tests/FloatingPanelTests.swift
@@ -60,6 +60,120 @@ class FloatingPanelTests: XCTestCase {
         XCTAssertEqual(contentVC2.tableView.bounces, false)
     }
 
+    func test_getBackdropAlpha_1positions() {
+        class FloatingPanelLayout1Positions: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .full
+            let supportedPositions: Set<FloatingPanelPosition> = [.full]
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout1Positions()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos - 100.0, with: CGPoint(x: 0.0, y: -100.0)), 0.3)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos, with: CGPoint(x: 0.0, y: 0.0)), 0.3)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos + 100.0, with: CGPoint(x: 0.0, y: 100.0)), 0.3) // ok??
+    }
+
+    func test_getBackdropAlpha_2positions() {
+        class FloatingPanelLayout2Positions: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .half
+            let supportedPositions: Set<FloatingPanelPosition> = [.half, .full]
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout2Positions()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let halfPos = fpc.originYOfSurface(for: .half)
+        let distance1 = abs(halfPos - fullPos)
+
+        fpc.move(to: .full, animated: false)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos, with: CGPoint(x: 0.0, y: 0.0)), 0.3)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos + distance1 * 0.5, with: CGPoint(x: 0.0, y: distance1 * 0.5)), 0.3 * 0.5)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: halfPos, with: CGPoint(x: 0.0, y: distance1)), 0.0)
+
+        fpc.move(to: .half, animated: false)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: halfPos, with: CGPoint(x: 0.0, y: 0.0)), 0.0)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos + distance1 * 0.5, with: CGPoint(x: 0.0, y: -0.5 * distance1)), 0.3 * 0.5)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos, with: CGPoint(x: 0.0, y: -1 * distance1)), 0.3)
+    }
+
+    func test_getBackdropAlpha_2positionsWithHidden() {
+        class FloatingPanelLayout2Positions: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .hidden
+            let supportedPositions: Set<FloatingPanelPosition> = [.hidden, .full]
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout2Positions()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let hiddenPos = fpc.originYOfSurface(for: .hidden)
+
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos - 100.0, with: CGPoint(x: 0.0, y: -100.0)), 0.3)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos, with: CGPoint(x: 0.0, y: 0.0)), 0.3)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: hiddenPos, with: CGPoint(x: 0.0, y: 100.0)), 0.0)
+    }
+
+    func test_getBackdropAlpha_3positions() {
+        let fpc = FloatingPanelController()
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let halfPos = fpc.originYOfSurface(for: .half)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+        let distance1 = abs(halfPos - fullPos)
+        let distance2 = abs(tipPos - halfPos)
+
+        fpc.move(to: .full, animated: false)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos, with: CGPoint(x: 0.0, y: 0.0)), 0.3)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos + distance1 * 0.5, with: CGPoint(x: 0.0, y: distance1 * 0.5)), 0.3 * 0.5)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: halfPos, with: CGPoint(x: 0.0, y: distance1)), 0.0)
+
+        fpc.move(to: .half, animated: false)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: halfPos, with: CGPoint(x: 0.0, y: 0.0)), 0.0)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos + distance1 * 0.5, with: CGPoint(x: 0.0, y: -0.5 * distance1)), 0.3 * 0.5)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: fullPos, with: CGPoint(x: 0.0, y: -1 * distance1)), 0.3)
+
+        fpc.move(to: .tip, animated: false)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: tipPos, with: CGPoint(x: 0.0, y: 0.0)), 0.0)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: halfPos + distance2 * 0.5, with: CGPoint(x: 0.0, y: -0.5 * distance2)), 0.0)
+        XCTAssertEqual(fpc.floatingPanel.getBackdropAlpha(at: halfPos, with: CGPoint(x: 0.0, y: -1 * distance2)), 0.0)
+    }
+
+    func test_targetPosition_1positions() {
+        class FloatingPanelLayout1Positions: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .full
+            let supportedPositions: Set<FloatingPanelPosition> = [.full]
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayout1Positions()
+
+        let fpc = FloatingPanelController(delegate: delegate)
+        fpc.showForTest()
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+
+        fpc.move(to: .full, animated: false)
+        assertTargetPosition(fpc.floatingPanel, with: [
+            (#line, fullPos - 10.0, CGPoint(x: 0.0, y: 1000.0), .full), // redirect
+            (#line, fullPos, CGPoint(x: 0.0, y: -1000.0), .full), // redirect
+            (#line, fullPos, CGPoint(x: 0.0, y: -100.0), .full), // redirect
+            (#line, fullPos, CGPoint(x: 0.0, y: 0.0), .full),
+            (#line, fullPos, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            (#line, fullPos, CGPoint(x: 0.0, y: 1000.0), .full), // redirect
+            (#line, fullPos + 10.0, CGPoint(x: 0.0, y: 100.0), .full), // redirect
+            ])
+    }
+
     func test_targetPosition_2positions() {
         class FloatingPanelLayout2Positions: FloatingPanelTestLayout {
             let initialPosition: FloatingPanelPosition = .half

--- a/Framework/Tests/FloatingPanelTests.swift
+++ b/Framework/Tests/FloatingPanelTests.swift
@@ -62,14 +62,6 @@ class FloatingPanelTests: XCTestCase {
 
 }
 
-private extension FloatingPanelController {
-    func showForTest() {
-        loadViewIfNeeded()
-        view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
-        show(animated: false, completion: nil)
-    }
-}
-
 private protocol FloatingPanelTestLayout: FloatingPanelLayout {}
 private extension FloatingPanelTestLayout {
     func insetFor(position: FloatingPanelPosition) -> CGFloat? {

--- a/Framework/Tests/FloatingPanelTests.swift
+++ b/Framework/Tests/FloatingPanelTests.swift
@@ -7,22 +7,19 @@ import XCTest
 @testable import FloatingPanel
 
 class FloatingPanelTests: XCTestCase {
-
     override func setUp() {}
-
     override func tearDown() {}
 
     func test_scrolllock() {
         let fpc = FloatingPanelController()
-        fpc.loadViewIfNeeded()
-        fpc.view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
+
         let contentVC1 = UITableViewController(nibName: nil, bundle: nil)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, true)
         XCTAssertEqual(contentVC1.tableView.bounces, true)
-
         fpc.set(contentViewController: contentVC1)
         fpc.track(scrollView: contentVC1.tableView)
-        fpc.show(animated: false, completion: nil) // half
+        fpc.showForTest()
+
         XCTAssertEqual(fpc.position, .half)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, false)
         XCTAssertEqual(contentVC1.tableView.bounces, false)
@@ -63,6 +60,14 @@ class FloatingPanelTests: XCTestCase {
         XCTAssertEqual(contentVC2.tableView.bounces, false)
     }
 
+}
+
+private extension FloatingPanelController {
+    func showForTest() {
+        loadViewIfNeeded()
+        view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
+        show(animated: false, completion: nil)
+    }
 }
 
 private protocol FloatingPanelTestLayout: FloatingPanelLayout {}

--- a/Framework/Tests/Utils.swift
+++ b/Framework/Tests/Utils.swift
@@ -28,3 +28,15 @@ class FloatingPanelTestDelegate: FloatingPanelControllerDelegate {
         return behavior
     }
 }
+
+protocol FloatingPanelTestLayout: FloatingPanelFullScreenLayout {}
+extension FloatingPanelTestLayout {
+    func insetFor(position: FloatingPanelPosition) -> CGFloat? {
+        switch position {
+        case .full: return 20.0
+        case .half: return 250.0
+        case .tip: return 60.0
+        default: return nil
+        }
+    }
+}

--- a/Framework/Tests/Utils.swift
+++ b/Framework/Tests/Utils.swift
@@ -10,6 +10,14 @@ func waitRunLoop(secs: TimeInterval = 0) {
     RunLoop.main.run(until: Date(timeIntervalSinceNow: secs))
 }
 
+extension FloatingPanelController {
+    func showForTest() {
+        loadViewIfNeeded()
+        view.frame = CGRect(x: 0, y: 0, width: 375, height: 667)
+        show(animated: false, completion: nil)
+    }
+}
+
 class FloatingPanelTestDelegate: FloatingPanelControllerDelegate {
     var layout: FloatingPanelLayout?
     func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {

--- a/Framework/Tests/Utils.swift
+++ b/Framework/Tests/Utils.swift
@@ -20,7 +20,11 @@ extension FloatingPanelController {
 
 class FloatingPanelTestDelegate: FloatingPanelControllerDelegate {
     var layout: FloatingPanelLayout?
+    var behavior: FloatingPanelBehavior?
     func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
         return layout
+    }
+    func floatingPanel(_ vc: FloatingPanelController, behaviorFor newCollection: UITraitCollection) -> FloatingPanelBehavior? {
+        return behavior
     }
 }


### PR DESCRIPTION
I refactored the logic to handle the anchor positions appropriately including `.hidden` by unit tests.

As a result, that makes this library robust and sophisticated. In theory, now it's able to handle more than 3 supported positions and it's easy to inverse the direction. 

That's why this is a big milestone to implement top-to-bottom panel.

Additionally, this has 2 fixes, animation interruption and the scroll locking bug by an interruption, to improve the robustness.

Related issues:  #175