### PR TITLE
Add the possibility to use drag dependent animations

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -53,6 +53,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     var interactionInProgress: Bool = false
     var isDecelerating: Bool = false
 
+    // Animation handling
+    private var alreadyMovedTranslationOfPan: CGPoint = CGPoint.zero
+    private var totalYTranslation: CGFloat = CGFloat(0)
+    private var nextState: FloatingPanelPosition = .tip
+
     // Scroll handling
     private var initialScrollOffset: CGPoint = .zero
     private var initialScrollFrame: CGRect = .zero
@@ -245,23 +250,25 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
     // MARK: - Gesture handling
     @objc func handle(panGesture: UIPanGestureRecognizer) {
+        // Direction of drag
         let velocity = panGesture.velocity(in: panGesture.view)
+        // Vector of starting point of drag and current finger position on screen
+        let translation = panGesture.translation(in: panGestureRecognizer.view!.superview)
 
         switch panGesture {
         case scrollView?.panGestureRecognizer:
             guard let scrollView = scrollView else { return }
 
+            // Location of finger in surfaceView -> on the FloatingPanel
             let location = panGesture.location(in: surfaceView)
 
-            let belowTop = surfaceView.frame.minY > layoutAdapter.topY
-
             log.debug("scroll gesture(\(state):\(panGesture.state)) --",
-                "belowTop = \(belowTop),",
+                "belowTop = \(!self.isFloatingPanelAtTopMostPosition()),",
                 "interactionInProgress = \(interactionInProgress),",
                 "scroll offset = \(scrollView.contentOffset.y),",
                 "location = \(location.y), velocity = \(velocity.y)")
 
-            if belowTop {
+            if !self.isFloatingPanelAtTopMostPosition() {
                 // Scroll offset pinning
                 if state == layoutAdapter.topMostState {
                     if interactionInProgress {
@@ -275,7 +282,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                             let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
                             if offset < 0 {
                                 fitToBounds(scrollView: scrollView)
-                                let translation = panGesture.translation(in: panGestureRecognizer.view!.superview)
                                 startInteraction(with: translation, at: location)
                             }
                         }
@@ -296,31 +302,16 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                     let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
                     if state == layoutAdapter.topMostState, offset < 0, velocity.y > 0 {
                         fitToBounds(scrollView: scrollView)
-                        let translation = panGesture.translation(in: panGestureRecognizer.view!.superview)
                         startInteraction(with: translation, at: location)
                     }
                 }
             }
+
         case panGestureRecognizer:
-            let translation = panGesture.translation(in: panGestureRecognizer.view!.superview)
             let location = panGesture.location(in: panGesture.view)
 
             log.debug("panel gesture(\(state):\(panGesture.state)) --",
                 "translation =  \(translation.y), location = \(location.y), velocity = \(velocity.y)")
-
-            if let animator = self.animator {
-                log.debug("panel animation interrupted!!!")
-                if animator.isInterruptible {
-                    animator.stopAnimation(false)
-                    animator.finishAnimation(at: .current)
-                }
-                self.animator = nil
-
-                // A user can stop a panel at the nearest Y of a target position
-                if abs(surfaceView.frame.minY - layoutAdapter.topY) < 1.0 {
-                    surfaceView.frame.origin.y = layoutAdapter.topY
-                }
-            }
 
             if interactionInProgress == false,
                 viewcontroller.delegate?.floatingPanelShouldBeginDragging(viewcontroller) == false {
@@ -328,7 +319,13 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             }
 
             if panGesture.state == .began {
-                panningBegan(at: location)
+                panningBegan(at: location, translation: translation, velocity: velocity)
+
+                if self.state != self.layoutAdapter.topMostState {
+                    self.animateFloatingPanel(with: velocity, translation: translation)
+                }
+                self.alreadyMovedTranslationOfPan = .zero
+
                 return
             }
 
@@ -341,7 +338,18 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 if interactionInProgress == false {
                     startInteraction(with: translation, at: location)
                 }
-                panningChange(with: translation)
+
+                if let scrollView = self.scrollView {
+                    // Check the scrollView's contentOffset in order to determine whether or not to start a new animation
+                    // This is necessary to ensure a new animation is not started when the floating panel is at the
+                    // top but the scrollView is not.
+                    if interactionInProgress && scrollView.contentOffset.y < CGFloat(0) && self.animator == nil {
+                        self.alreadyMovedTranslationOfPan = translation
+                        self.animateFloatingPanel(with: velocity, translation: translation)
+                    }
+                }
+
+                panningChange(translation: translation, velocity: velocity)
             case .ended, .cancelled, .failed:
                 panningEnd(with: translation, velocity: velocity)
             default:
@@ -350,6 +358,31 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         default:
             return
         }
+    }
+
+    private func animateFloatingPanel(with velocity: CGPoint, translation: CGPoint) {
+        let targetPosition = self.nextPosition(with: velocity)
+        let distance = self.distance(to: targetPosition)
+
+        log.debug("startAnimation to \(targetPosition) -- distance = \(distance), velocity = \(velocity.y)")
+
+        isDecelerating = true
+        viewcontroller.delegate?.floatingPanelWillBeginDecelerating(viewcontroller)
+
+        self.startNewAnimator(for: distance, with: velocity, movingTo: targetPosition)
+    }
+
+    private func isFloatingPanelAtTopMostPosition() -> Bool {
+        guard let animator = self.animator else {
+            return self.state == self.layoutAdapter.topMostState
+        }
+
+        return (
+            // Moving panel to topMostState
+            (self.nextState == self.layoutAdapter.topMostState && animator.fractionComplete >= 1)
+            // Moving panel from topMostState
+            || (self.state == self.layoutAdapter.topMostState && animator.fractionComplete <= 0)
+        )
     }
 
     private func shouldScrollViewHandleTouch(_ scrollView: UIScrollView?, point: CGPoint, velocity: CGPoint) -> Bool {
@@ -368,43 +401,58 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
             }
         }
 
-        guard
-            state == layoutAdapter.topMostState,   // When not top most(i.e. .full), don't scroll.
-            interactionInProgress == false,        // When interaction already in progress, don't scroll.
-            surfaceView.frame.minY == layoutAdapter.topY
-        else {
+        guard self.isFloatingPanelAtTopMostPosition(), self.interactionInProgress else {
             return false
         }
 
         // When the current and initial point within grabber area, do scroll.
-        if grabberAreaFrame.contains(point), !grabberAreaFrame.contains(initialLocation) {
+        if grabberAreaFrame.contains(point) && !grabberAreaFrame.contains(initialLocation) {
             return true
         }
 
-        guard
-            scrollView.frame.contains(initialLocation), // When initialLocation not in scrollView, don't scroll.
-            !grabberAreaFrame.contains(point)           // When point within grabber area, don't scroll.
-        else {
+        if !scrollView.frame.contains(initialLocation) && // When initialLocation not in scrollView, don't scroll.
+             grabberAreaFrame.contains(point)            // When point within grabber area, don't scroll.
+        {
             return false
         }
 
         let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
         // The zero offset must be excluded because the offset is usually zero
         // after a panel moves from half/tip to full.
-        if  offset > 0.0 {
-            return true
-        }
-        if scrollView.isDecelerating {
-            return true
-        }
-        if velocity.y <= 0 {
+        if  offset > 0.0 || scrollView.isDecelerating || velocity.y <= 0 {
             return true
         }
 
         return false
     }
 
-    private func panningBegan(at location: CGPoint) {
+    private func nextPosition(with velocity: CGPoint) -> FloatingPanelPosition {
+        let isPanelMovingUpwards = velocity.y < CGFloat(0)
+
+        switch self.state {
+        case .full:
+            return isPanelMovingUpwards ? .full : .half
+        case .half:
+            return isPanelMovingUpwards ? .full : .tip
+        case .tip:
+            if isPanelMovingUpwards {
+                return .half
+            }
+            if self.layoutAdapter.supportedPositions.contains(.hidden) {
+                return .hidden
+            }
+
+            return .tip
+        case .hidden:
+            guard isPanelMovingUpwards else {
+                fatalError("Cannot move pannel downwards if already hidden!")
+            }
+
+            return .tip
+        }
+    }
+
+    private func panningBegan(at location: CGPoint, translation: CGPoint, velocity: CGPoint) {
         // A user interaction does not always start from Began state of the pan gesture
         // because it can be recognized in scrolling a content in a content view controller.
         // So here just preserve the current state if needed.
@@ -421,22 +469,95 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         }
     }
 
-    private func panningChange(with translation: CGPoint) {
+    private func panningChange(translation: CGPoint, velocity: CGPoint) {
         log.debug("panningChange -- translation = \(translation.y)")
-        let pre = surfaceView.frame.minY
-        let dy = translation.y - initialTranslationY
 
-        layoutAdapter.updateInteractiveTopConstraint(diff: dy,
-                                                     allowsTopBuffer: allowsTopBuffer(for: dy),
-                                                     with: behavior)
+        guard let animator = self.animator else {
+            return
+        }
 
-        backdropView.alpha = getBackdropAlpha(with: translation)
-        preserveContentVCLayoutIfNeeded()
+        // Moving the finger upwards on the screen results in a negative Y translation. But since the animations are
+        // defined to progress when moving from bottom to top, we have to negate the gesture recognizer translation
+        // to get a positive animation completion fraction.
+        var fraction = (-1 * (translation.y - self.alreadyMovedTranslationOfPan.y)) / self.totalYTranslation
 
-        let didMove = (pre != surfaceView.frame.minY)
-        guard didMove else { return }
+        // In order to still use the correct value for the fraction (-> value between 0 and 1) when the panel is moved
+        // downwards we need to multiply it by -1.
+        if (self.state == .full && self.nextState == .half) || (self.state == .half && self.nextState == .tip) {
+            fraction *= -1
+        }
 
-        viewcontroller.delegate?.floatingPanelDidMove(viewcontroller)
+        // In order to still use the correct value for the fraction (-> value between 0 and 1) we need to multiply it
+        // by -1 when the animator is reversed
+        if animator.isReversed {
+            fraction *= -1
+        }
+
+        let previousFractionComplete = animator.fractionComplete
+
+        // Manually set the fractionComplete value of the animator so the progress of animator corresponds with the
+        // drag on the floating panel as well as its current position on the screen.
+        animator.fractionComplete = fraction
+
+        // When the floating panel transitions from one state to another we need to also start a new animation.
+        // Therefor, we need to check whether the currenlty running animator is either finished OR got back to its
+        // starting point.
+        // There are two cases here since the user could drag the panel eg. from .tip over .half to .full but change
+        // directions midway between .half and .full and drag the panel back downards.
+        if (animator.fractionComplete == 1) || (fraction < 0 && self.nextState != self.state) {
+            self.state = (fraction < 0) ? self.state : self.nextState
+            let newTargetState = self.nextPosition(with: velocity)
+            let distance = self.distance(to: newTargetState)
+
+            self.startNewAnimator(for: distance, with: velocity, movingTo: newTargetState)
+            // Since the drag is already in progress we need 'save' the already travelled distance on the screen in
+            // order to calculate the correct translation when calcualting the fraction (-> progress) of the animator.
+            // Otherwise the panel 'jumps' from its current position to the finger's position on the screen.
+            self.alreadyMovedTranslationOfPan = translation
+        }
+
+        self.preserveContentVCLayoutIfNeeded()
+        // Determine whether or not the panel has actually moved.
+        if animator.fractionComplete != previousFractionComplete {
+            viewcontroller.delegate?.floatingPanelDidMove(viewcontroller)
+        }
+    }
+
+    private func startNewAnimator(for distance: CGFloat, with velocity: CGPoint, movingTo targetState: FloatingPanelPosition) {
+        let velocityVector = (distance != CGFloat(0)) ? CGVector(dx: 0, dy: min(abs(velocity.y)/distance, 30.0)) : .zero
+
+        let animator = behavior.interactionAnimator(self.viewcontroller, between: self.state, and: targetState, with: velocityVector)
+        animator.addAnimations { [weak self] in
+            guard let `self` = self else { return }
+            // Set layout (-> therefor the top constraint of the FloatingPanel) to the next upcoming state in order to
+            // be able to move the panel during a drag
+            self.updateLayout(to: targetState)
+        }
+        animator.addCompletion { [weak self] pos in
+            guard let `self` = self else { return }
+            if pos == .end && self.animator?.isReversed == false {
+                self.state = self.nextState
+            }
+            // Set layout again to ensure that the panel's top constraint corresponds with the desired state.
+            self.updateLayout(to: self.state)
+            self.animationDidComplete(at: self.state)
+        }
+
+        self.animator = animator
+        self.nextState = targetState
+
+        // In order to make animators drag-dynamic we need to start and immediatly pause the animator aftwards.
+        animator.startAnimation()
+        animator.pauseAnimation()
+
+        // Calculate the total distance the floating panel has to move between its current state and its next state.
+        // Depending on the direction of the drag we need turn the calcualtion around in order to still get a positive
+        // value for totalYTranslation.
+        if velocity.y < CGFloat(0) {
+            self.totalYTranslation = abs(self.layoutAdapter.positionY(for: self.state) - self.layoutAdapter.positionY(for: nextState))
+        } else if velocity.y > CGFloat(0) {
+            self.totalYTranslation = abs(self.layoutAdapter.positionY(for: nextState) - self.layoutAdapter.positionY(for: self.state))
+        }
     }
 
     private func allowsTopBuffer(for translationY: CGFloat) -> Bool {
@@ -521,24 +642,34 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
                 self.startRemovalAnimation(with: velocityVector) { [weak self] in
                     self?.finishRemovalAnimation()
                 }
-                return
             }
         }
 
         viewcontroller.delegate?.floatingPanelDidEndDragging(viewcontroller, withVelocity: velocity, targetPosition: targetPosition)
 
+        guard let animator = self.animator else {
+            return
+        }
+
         // Workaround: Disable a tracking scroll to prevent bouncing a scroll content in a panel animating
-        let isScrollEnabled = scrollView?.isScrollEnabled
+        let wasScrollEnabled = self.scrollView?.isScrollEnabled
         if let scrollView = scrollView, targetPosition != .full {
             scrollView.isScrollEnabled = false
         }
 
-        startAnimation(to: targetPosition, at: distance, with: velocity)
+        if velocity.y != 0 {
+            // Since we assume that the threshold for changing the panel's state is the halfway point between two
+            // states, we can also assume that when the user stopped dragging the panel before reaching this halfway
+            // point the panel moves back to its original state which means that the animation needs to be reversed aka
+            // played backwards.
+            animator.isReversed = animator.fractionComplete < 0.5
+        }
+        // Since the user stopped moving the panel, we need to let the animator finish the animation completely.
+        animator.continueAnimation(withTimingParameters: nil, durationFactor: 0)
 
         // Workaround: Reset `self.scrollView.isScrollEnabled`
-        if let scrollView = scrollView, targetPosition != .full,
-            let isScrollEnabled = isScrollEnabled {
-            scrollView.isScrollEnabled = isScrollEnabled
+        if let wasScrollEnabled = wasScrollEnabled {
+            self.scrollView?.isScrollEnabled = wasScrollEnabled
         }
     }
 
@@ -627,29 +758,8 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         panGestureRecognizer.isEnabled = true
     }
 
-    private func startAnimation(to targetPosition: FloatingPanelPosition, at distance: CGFloat, with velocity: CGPoint) {
-        log.debug("startAnimation to \(targetPosition) -- distance = \(distance), velocity = \(velocity.y)")
-
-        isDecelerating = true
-        viewcontroller.delegate?.floatingPanelWillBeginDecelerating(viewcontroller)
-
-        let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: min(abs(velocity.y)/distance, 30.0)) : .zero
-        let animator = behavior.interactionAnimator(self.viewcontroller, to: targetPosition, with: velocityVector)
-        animator.addAnimations { [weak self] in
-            guard let `self` = self else { return }
-            self.state = targetPosition
-            self.updateLayout(to: targetPosition)
-        }
-        animator.addCompletion { [weak self] pos in
-            guard let `self` = self else { return }
-            self.finishAnimation(at: targetPosition)
-        }
-        self.animator = animator
-        animator.startAnimation()
-    }
-
-    private func finishAnimation(at targetPosition: FloatingPanelPosition) {
-        log.debug("finishAnimation to \(targetPosition)")
+    private func animationDidComplete(at targetPosition: FloatingPanelPosition) {
+        log.debug("animationDidComplete to \(targetPosition)")
 
         self.isDecelerating = false
         self.animator = nil
@@ -657,7 +767,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
         self.viewcontroller.delegate?.floatingPanelDidEndDecelerating(self.viewcontroller)
 
         if let scrollView = scrollView {
-            log.debug("finishAnimation -- scroll offset = \(scrollView.contentOffset)")
+            log.debug("animationDidComplete -- scroll offset = \(scrollView.contentOffset)")
         }
 
         stopScrollDeceleration = false
@@ -767,22 +877,14 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
 
             let redirectionalProgress = max(min(behavior.redirectionalProgress(viewcontroller, from: state, to: nextState), 1.0), 0.0)
 
-            let th1: CGFloat
-            let th2: CGFloat
-
-            if forwardYDirection {
-                th1 = topY + (middleY - topY) * redirectionalProgress
-                th2 = middleY + (bottomY - middleY) * redirectionalProgress
-            } else {
-                th1 = middleY - (middleY - topY) * redirectionalProgress
-                th2 = bottomY - (bottomY - middleY) * redirectionalProgress
-            }
+            let th1: CGFloat = topY + (middleY - topY) * redirectionalProgress
+            let th2: CGFloat = middleY + (bottomY - middleY) * redirectionalProgress
 
             let decelerationRate = behavior.momentumProjectionRate(viewcontroller)
 
             let baseY = abs(bottomY - topY)
-            let vecY = velocity.y / baseY
-            let pY = project(initialVelocity: vecY, decelerationRate: decelerationRate) * baseY + currentY
+            let velocityY = velocity.y / baseY
+            let pY = project(initialVelocity: velocityY, decelerationRate: decelerationRate) * baseY + currentY
 
             switch currentY {
             case ..<th1:
@@ -886,7 +988,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate, UIScrollViewDelegate
     }
 
     private func unlockScrollView() {
-        guard let scrollView = scrollView, isScrollLocked else { return }
+        guard let scrollView = scrollView else { return }
 
         isScrollLocked = false
 

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -23,7 +23,7 @@ public protocol FloatingPanelBehavior {
     func redirectionalProgress(_ fpc: FloatingPanelController, from: FloatingPanelPosition, to: FloatingPanelPosition) -> CGFloat
 
     /// Returns a UIViewPropertyAnimator object to project a floating panel to a position on finger up if the user dragged.
-    func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator
+    func interactionAnimator(_ fpc: FloatingPanelController, between position1: FloatingPanelPosition, and position2: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator
 
     /// Returns a UIViewPropertyAnimator object to add a floating panel to a position.
     ///
@@ -89,8 +89,8 @@ public extension FloatingPanelBehavior {
         return 0.5
     }
 
-    func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
-        return defaultBehavior.interactionAnimator(fpc, to: targetPosition, with: velocity)
+    func interactionAnimator(_ fpc: FloatingPanelController, between position1: FloatingPanelPosition, and position2: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
+        return defaultBehavior.interactionAnimator(fpc, between: position1, and: position2, with: velocity)
     }
 
     func addAnimator(_ fpc: FloatingPanelController, to: FloatingPanelPosition) -> UIViewPropertyAnimator {
@@ -131,10 +131,9 @@ private let defaultBehavior = FloatingPanelDefaultBehavior()
 public class FloatingPanelDefaultBehavior: FloatingPanelBehavior {
     public init() { }
 
-    public func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
+    public func interactionAnimator(_ fpc: FloatingPanelController, between position1: FloatingPanelPosition, and position2: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
         let timing = timeingCurve(with: velocity)
         let animator = UIViewPropertyAnimator(duration: 0, timingParameters: timing)
-        animator.isInterruptible = false
         return animator
     }
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -412,51 +412,6 @@ class FloatingPanelLayoutAdapter {
         }
     }
 
-    func updateInteractiveTopConstraint(diff: CGFloat, allowsTopBuffer: Bool, with behavior: FloatingPanelBehavior) {
-        defer {
-            surfaceView.superview!.layoutIfNeeded() // MUST call here to update `surfaceView.frame`
-        }
-
-        let topMostConst: CGFloat = {
-            var ret: CGFloat = 0.0
-            switch layout {
-            case is FloatingPanelIntrinsicLayout, is FloatingPanelFullScreenLayout:
-                ret = topY
-            default:
-                ret = topY - safeAreaInsets.top
-            }
-            return max(ret, 0.0) // The top boundary is equal to the related topAnchor.
-        }()
-        let bottomMostConst: CGFloat = {
-            var ret: CGFloat = 0.0
-            switch layout {
-            case is FloatingPanelIntrinsicLayout, is FloatingPanelFullScreenLayout:
-                ret = bottomY
-            default:
-                ret = bottomY - safeAreaInsets.top
-            }
-            return min(ret, bottomMaxY)
-        }()
-        let minConst = allowsTopBuffer ? topMostConst - layout.topInteractionBuffer : topMostConst
-        let maxConst = bottomMostConst + layout.bottomInteractionBuffer
-
-        var const = initialConst + diff
-
-        // Rubberbanding top buffer
-        if behavior.allowsRubberBanding(for: .top), const < topMostConst {
-            let buffer = topMostConst - const
-            const = topMostConst - rubberbandEffect(for: buffer, base: vc.view.bounds.height)
-        }
-
-        // Rubberbanding bottom buffer
-        if behavior.allowsRubberBanding(for: .bottom), const > bottomMostConst {
-            let buffer = const - bottomMostConst
-            const = bottomMostConst + rubberbandEffect(for: buffer, base: vc.view.bounds.height)
-        }
-
-        interactiveTopConstraint?.constant = max(minConst, min(maxConst, const))
-    }
-
     // According to @chpwn's tweet: https://twitter.com/chpwn/status/285540192096497664
     // x = distance from the edge
     // c = constant value, UIScrollView uses 0.55


### PR DESCRIPTION
This PR adds the possibility to add drag dependent animations to the FloatingPanel content controller. 

Therefore, it was necessary to do an in-depth refactoring of `FloatingPanel`. 
Now, an animator is initiated right when a drag is started and a second one is started dynamically when the floating panel is dragged over the inset of the next position.
If the drag is ended when the floating panel is between two positions, it is determined to which position the panel is closest resulting in the animation being either finished or reversed.
In addition to that, to fully control the animation between different positions the `interactionAnimator` now gets the starting position of the floating panel and its target position as parameters, so one can define a position-specific animation.