### PR TITLE
Fix bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ jobs:
   - stage: CocoaPods
     osx_image: xcode10.2
     script:
-    - pod spec lint
-    - pod lib lint
+    - pod spec lint --allow-warnings
+    - pod lib lint --allow-warnings
 
   - stage: Build examples
     osx_image: xcode10.2

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -933,7 +933,7 @@ extension TabBarContentViewController: UITextViewDelegate {
         // Using KVO of `scrollView.contentOffset`). Because it can lead to an
         // infinite loop if a user also resets a content offset as below and,
         // in the situation, a user has to modify the library.
-        if fpc.position != .full, fpc.surfaceView.frame.minY < fpc.originYOfSurface(for: .full) {
+        if fpc.position != .full, fpc.surfaceView.frame.minY > fpc.originYOfSurface(for: .full) {
             scrollView.contentOffset = .zero
         }
     }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -659,7 +659,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
 
         vc.delegate?.floatingPanelWillBeginDecelerating(vc)
 
-        let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: min(abs(velocity.y)/distance, 30.0)) : .zero
+        let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: abs(velocity.y)/distance) : .zero
         let animator = behavior.interactionAnimator(vc, to: targetPosition, with: velocityVector)
         animator.addAnimations { [weak self] in
             guard let `self` = self else { return }

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -317,17 +317,18 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
 
             if let animator = self.animator {
                 guard surfaceView.presentationFrame.minY - layoutAdapter.topY > -1.0 else { return }
-                guard animator.isInterruptible else { return }
                 log.debug("panel animation interrupted!!!")
 
-                animator.stopAnimation(false)
-                // A user can stop a panel at the nearest Y of a target position so this fine-tunes
-                // the a small gap between the presentation layer frame and model layer frame
-                // to unlock scroll view properly at finishAnimation(at:)
-                if abs(surfaceView.frame.minY - layoutAdapter.topY) <= 1.0 {
-                    surfaceView.frame.origin.y = layoutAdapter.topY
+                if animator.isInterruptible {
+                    animator.stopAnimation(false)
+                    // A user can stop a panel at the nearest Y of a target position so this fine-tunes
+                    // the a small gap between the presentation layer frame and model layer frame
+                    // to unlock scroll view properly at finishAnimation(at:)
+                    if abs(surfaceView.frame.minY - layoutAdapter.topY) <= 1.0 {
+                        surfaceView.frame.origin.y = layoutAdapter.topY
+                    }
+                    animator.finishAnimation(at: .current)
                 }
-                animator.finishAnimation(at: .current)
             }
 
             if interactionInProgress == false,

--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -127,6 +127,7 @@ public class FloatingPanelDefaultBehavior: FloatingPanelBehavior {
     public func interactionAnimator(_ fpc: FloatingPanelController, to targetPosition: FloatingPanelPosition, with velocity: CGVector) -> UIViewPropertyAnimator {
         let timing = timeingCurve(with: velocity)
         let animator = UIViewPropertyAnimator(duration: 0, timingParameters: timing)
+        animator.isInterruptible = false // Prevent a propagation of the animation(spring etc) to a content view
         return animator
     }
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -50,6 +50,9 @@ public protocol FloatingPanelLayout: class {
     var topInteractionBuffer: CGFloat { get }
 
     /// Return the interaction buffer to the bottom from the bottom position. Default is 6.0.
+    ///
+    /// - Important:
+    /// The specified buffer is ignored when `FloatingPanelController.isRemovalInteractionEnabled` is set to true.
     var bottomInteractionBuffer: CGFloat { get }
 
     /// Returns a CGFloat value to determine a Y coordinate of a floating panel for each position(full, half, tip and hidden).
@@ -135,7 +138,7 @@ struct LayoutSegment {
 }
 
 class FloatingPanelLayoutAdapter {
-    weak var vc: UIViewController!
+    weak var vc: FloatingPanelController!
     private weak var surfaceView: FloatingPanelSurfaceView!
     private weak var backdropView: FloatingPanelBackdropView!
 
@@ -276,7 +279,7 @@ class FloatingPanelLayoutAdapter {
                   ", content safe area(bottom) =", safeAreaBottom)
     }
 
-    func prepareLayout(in vc: UIViewController) {
+    func prepareLayout(in vc: FloatingPanelController) {
         self.vc = vc
 
         NSLayoutConstraint.deactivate(fixedConstraints + fullConstraints + halfConstraints + tipConstraints + offConstraints)
@@ -415,11 +418,12 @@ class FloatingPanelLayoutAdapter {
         }()
         let bottomMostConst: CGFloat = {
             var ret: CGFloat = 0.0
+            let _bottomY = vc.isRemovalInteractionEnabled ? positionY(for: .hidden) : bottomY
             switch layout {
             case is FloatingPanelIntrinsicLayout, is FloatingPanelFullScreenLayout:
-                ret = bottomY
+                ret = _bottomY
             default:
-                ret = bottomY - safeAreaInsets.top
+                ret = _bottomY - safeAreaInsets.top
             }
             return min(ret, bottomMaxY)
         }()


### PR DESCRIPTION
* Revert isInterruptible property of the default animator
     * Because it causes an unexpected propagation of the spring animation to
the content view. The propagation is reproduced on `fitToBounds` mode #145.
* Fix a scroll unlock on an animation interruption
* Remove the velocity vector limit
* Fix the bottom buffer of a removable panel