### PR TITLE
Release 1.6.4

### DIFF
--- a/FloatingPanel.podspec
+++ b/FloatingPanel.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                = "FloatingPanel"
-  s.version             = "1.6.3"
+  s.version             = "1.6.4"
   s.summary             = "FloatingPanel is a clean and easy-to-use UI component of a floating panel interface."
   s.description         = <<-DESC
 FloatingPanel is a clean and easy-to-use UI component for a new interface introduced in Apple Maps, Shortcuts and Stocks app.

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -375,6 +375,9 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
                 }
                 panningChange(with: translation)
             case .ended, .cancelled, .failed:
+                if interactionInProgress == false {
+                    startInteraction(with: translation, at: location)
+                }
                 panningEnd(with: translation, velocity: velocity)
             default:
                 break

--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -337,6 +337,11 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
             log.debug("panel gesture(\(state):\(panGesture.state)) --",
                 "translation =  \(translation.y), location = \(location.y), velocity = \(velocity.y)")
 
+            if interactionInProgress == false, isDecelerating == false,
+                let vc = viewcontroller, vc.delegate?.floatingPanelShouldBeginDragging(vc) == false {
+                return
+            }
+
             if let animator = self.animator {
                 guard surfaceView.presentationFrame.minY >= layoutAdapter.topMaxY else { return }
                 log.debug("panel animation interrupted!!!")
@@ -352,12 +357,6 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
                 } else {
                     self.animator = nil
                 }
-            }
-
-            if interactionInProgress == false,
-                let vc = viewcontroller,
-                vc.delegate?.floatingPanelShouldBeginDragging(vc) == false {
-                return
             }
 
             if panGesture.state == .began {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -454,6 +454,7 @@ class FloatingPanelLayoutAdapter {
     func activateLayout(of state: FloatingPanelPosition) {
         defer {
             surfaceView.superview!.layoutIfNeeded()
+            log.debug("activateLayout -- surface.presentation = \(self.surfaceView.presentationFrame) surface.frame = \(self.surfaceView.frame)")
         }
 
         var state = state

--- a/Framework/Sources/Info.plist
+++ b/Framework/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.3</string>
+	<string>1.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
Bugfixes

* Fix not calling floatingPanelDidEndDecelerating delegate after interruption
* Always call startInteraction before endInteraction to keep the delegate call convention.
* Fix stopping a panel b/w anchors after an interruption