### PR TITLE
Call floatingPanelDidEndRemove when dismiss with tap on backdrop view

### DIFF
--- a/Framework/Sources/FloatingPanel.swift
+++ b/Framework/Sources/FloatingPanel.swift
@@ -264,7 +264,10 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
     // MARK: - Gesture handling
 
     @objc func handleBackdrop(tapGesture: UITapGestureRecognizer) {
-        viewcontroller?.dismiss(animated: true, completion: nil)
+        viewcontroller?.dismiss(animated: true) { [weak self] in
+            guard let vc = self?.viewcontroller else { return }
+            vc.delegate?.floatingPanelDidEndRemove(vc)
+        }
     }
 
     @objc func handle(panGesture: UIPanGestureRecognizer) {


### PR DESCRIPTION
By #205 added dismissing by backdrop view. But `floatingPanelDidEndRemove` is not called from it.

# reproduce
1. build sample app and run debug it.
2. set a break point to `SampleListViewController#floatingPanelDidEndRemove`
3. tap `Show Panel Modal` on sample app

When, `floatingPanelDidEndRemove` is not called