### PR TITLE
Support bottom content inset for container view

### DIFF
--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -312,8 +312,8 @@ extension SampleListViewController: UITableViewDelegate {
             
             let fpc = FloatingPanelController()
             fpc.set(contentViewController: contentViewController)
-            fpc.surfaceView.contentInsets = .init(top: 20, left: 20, bottom: 0, right: 20)
-            
+            fpc.surfaceView.contentInsets = .init(top: 20, left: 20, bottom: 20, right: 20)
+
             fpc.delegate = self
             fpc.isRemovalInteractionEnabled = true
             self.present(fpc, animated: true, completion: nil)
@@ -346,8 +346,10 @@ extension SampleListViewController: FloatingPanelControllerDelegate {
                 return ModalPanelLayout()
             }
             fallthrough
+        case .showContentInset:
+            return NoInteractionBufferPanelLayout()
         default:
-            return (newCollection.verticalSizeClass == .compact) ? nil  : self
+            return (newCollection.verticalSizeClass == .compact) ? nil : self
         }
     }
 
@@ -411,6 +413,27 @@ extension SampleListViewController: UIPageViewControllerDataSource {
 }
 
 class IntrinsicPanelLayout: FloatingPanelIntrinsicLayout { }
+
+class NoInteractionBufferPanelLayout: FloatingPanelLayout {
+    var initialPosition: FloatingPanelPosition {
+        return .full
+    }
+
+    func insetFor(position: FloatingPanelPosition) -> CGFloat? {
+        switch position {
+        case .full: return 0
+        default: return nil
+        }
+    }
+
+    var topInteractionBuffer: CGFloat {
+        return 0.0
+    }
+
+    var bottomInteractionBuffer: CGFloat {
+        return 0.0
+    }
+}
 
 class RemovablePanelLayout: FloatingPanelIntrinsicLayout {
     var supportedPositions: Set<FloatingPanelPosition> {

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -422,7 +422,9 @@ class NoInteractionBufferPanelLayout: FloatingPanelLayout {
     func insetFor(position: FloatingPanelPosition) -> CGFloat? {
         switch position {
         case .full: return 0
-        default: return nil
+        case .half: return 216
+        case .tip: return 60
+        case .hidden: return nil
         }
     }
 

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -436,7 +436,7 @@ class FloatingPanelLayoutAdapter {
         }
         NSLayoutConstraint.activate(constraint: heightConstraint)
 
-        surfaceView.bottomOverflow = layout.topInteractionBuffer
+        surfaceView.bottomOverflow = vc.view.bounds.height + layout.topInteractionBuffer
     }
 
     func updateInteractiveTopConstraint(diff: CGFloat, allowsTopBuffer: Bool, with behavior: FloatingPanelBehavior) {

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -436,7 +436,7 @@ class FloatingPanelLayoutAdapter {
         }
         NSLayoutConstraint.activate(constraint: heightConstraint)
 
-        surfaceView.bottomOverflow = vc.view.bounds.height + layout.topInteractionBuffer
+        surfaceView.bottomOverflow = layout.topInteractionBuffer
     }
 
     func updateInteractiveTopConstraint(diff: CGFloat, allowsTopBuffer: Bool, with behavior: FloatingPanelBehavior) {

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -36,8 +36,6 @@ public class FloatingPanelSurfaceView: UIView {
     public weak var contentView: UIView!
     
     /// The content insets specifying the insets around the content view.
-    ///
-    /// - important: Currently the `bottom` inset is ignored.
     public var contentInsets: UIEdgeInsets = .zero {
         didSet {
             // Needs update constraints
@@ -98,9 +96,6 @@ public class FloatingPanelSurfaceView: UIView {
 
     @available(*, unavailable, renamed: "containerView")
     public var backgroundView: UIView!
-
-    private lazy var containerViewTopInsetConstraint: NSLayoutConstraint = containerView.topAnchor.constraint(equalTo: topAnchor, constant: containerTopInset)
-    private lazy var containerViewHeightConstraint: NSLayoutConstraint = containerView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
     
     /// The content view top constraint
     private var contentViewTopConstraint: NSLayoutConstraint?
@@ -108,8 +103,8 @@ public class FloatingPanelSurfaceView: UIView {
     private var contentViewLeftConstraint: NSLayoutConstraint?
     /// The content right constraint
     private var contentViewRightConstraint: NSLayoutConstraint?
-    /// The content height constraint
-    private var contentViewHeightConstraint: NSLayoutConstraint?
+    /// The content bottom constraint
+    private var contentViewBottomConstraint: NSLayoutConstraint?
 
     private lazy var grabberHandleWidthConstraint: NSLayoutConstraint = grabberHandle.widthAnchor.constraint(equalToConstant: grabberHandleWidth)
     private lazy var grabberHandleHeightConstraint: NSLayoutConstraint = grabberHandle.heightAnchor.constraint(equalToConstant: grabberHandleHeight)
@@ -132,10 +127,10 @@ public class FloatingPanelSurfaceView: UIView {
         addSubview(containerView)
         containerView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            containerViewTopInsetConstraint,
-            containerView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0.0),
-            containerView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0.0),
-            containerViewHeightConstraint,
+            containerView.topAnchor.constraint(equalTo: topAnchor),
+            containerView.leftAnchor.constraint(equalTo: leftAnchor),
+            containerView.rightAnchor.constraint(equalTo: rightAnchor),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
             ])
 
         addSubview(grabberHandle)
@@ -149,13 +144,10 @@ public class FloatingPanelSurfaceView: UIView {
     }
 
     public override func updateConstraints() {
-        containerViewTopInsetConstraint.constant = containerTopInset
-        containerViewHeightConstraint.constant = bottomOverflow
-
         contentViewTopConstraint?.constant = contentInsets.top
         contentViewLeftConstraint?.constant = contentInsets.left
         contentViewRightConstraint?.constant = contentInsets.right
-        contentViewHeightConstraint?.constant = -containerTopInset
+        contentViewBottomConstraint?.constant = contentInsets.bottom - bottomOverflow
 
         grabberHandleTopConstraint.constant = grabberTopPadding
         grabberHandleWidthConstraint.constant = grabberHandleWidth
@@ -221,16 +213,17 @@ public class FloatingPanelSurfaceView: UIView {
         let topConstraint = contentView.topAnchor.constraint(equalTo: topAnchor, constant: contentInsets.top)
         let leftConstraint = contentView.leftAnchor.constraint(equalTo: leftAnchor, constant: contentInsets.left)
         let rightConstraint = rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: contentInsets.right)
+        let bottomConstraint = bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: contentInsets.bottom)
         let heightConstraint = contentView.heightAnchor.constraint(equalTo: heightAnchor, constant: -containerTopInset)
         NSLayoutConstraint.activate([
             topConstraint,
             leftConstraint,
             rightConstraint,
-            heightConstraint,
+            bottomConstraint,
             ])
         self.contentViewTopConstraint = topConstraint
         self.contentViewLeftConstraint = leftConstraint
         self.contentViewRightConstraint = rightConstraint
-        self.contentViewHeightConstraint = heightConstraint
+        self.contentViewBottomConstraint = bottomConstraint
     }
 }

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -96,6 +96,9 @@ public class FloatingPanelSurfaceView: UIView {
 
     @available(*, unavailable, renamed: "containerView")
     public var backgroundView: UIView!
+
+    private lazy var containerViewTopInsetConstraint: NSLayoutConstraint = containerView.topAnchor.constraint(equalTo: topAnchor, constant: containerTopInset)
+    private lazy var containerViewHeightConstraint: NSLayoutConstraint = containerView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
     
     /// The content view top constraint
     private var contentViewTopConstraint: NSLayoutConstraint?
@@ -103,8 +106,8 @@ public class FloatingPanelSurfaceView: UIView {
     private var contentViewLeftConstraint: NSLayoutConstraint?
     /// The content right constraint
     private var contentViewRightConstraint: NSLayoutConstraint?
-    /// The content bottom constraint
-    private var contentViewBottomConstraint: NSLayoutConstraint?
+    /// The content height constraint
+    private var contentViewHeightConstraint: NSLayoutConstraint?
 
     private lazy var grabberHandleWidthConstraint: NSLayoutConstraint = grabberHandle.widthAnchor.constraint(equalToConstant: grabberHandleWidth)
     private lazy var grabberHandleHeightConstraint: NSLayoutConstraint = grabberHandle.heightAnchor.constraint(equalToConstant: grabberHandleHeight)
@@ -127,10 +130,10 @@ public class FloatingPanelSurfaceView: UIView {
         addSubview(containerView)
         containerView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: topAnchor),
-            containerView.leftAnchor.constraint(equalTo: leftAnchor),
-            containerView.rightAnchor.constraint(equalTo: rightAnchor),
-            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            containerViewTopInsetConstraint,
+            containerView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0.0),
+            containerView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0.0),
+            containerViewHeightConstraint,
             ])
 
         addSubview(grabberHandle)
@@ -144,10 +147,13 @@ public class FloatingPanelSurfaceView: UIView {
     }
 
     public override func updateConstraints() {
+        containerViewTopInsetConstraint.constant = containerTopInset
+        containerViewHeightConstraint.constant = bottomOverflow
+
         contentViewTopConstraint?.constant = contentInsets.top
         contentViewLeftConstraint?.constant = contentInsets.left
         contentViewRightConstraint?.constant = contentInsets.right
-        contentViewBottomConstraint?.constant = contentInsets.bottom - bottomOverflow
+        contentViewHeightConstraint?.constant = -(containerTopInset + contentInsets.top + contentInsets.bottom)
 
         grabberHandleTopConstraint.constant = grabberTopPadding
         grabberHandleWidthConstraint.constant = grabberHandleWidth
@@ -213,17 +219,16 @@ public class FloatingPanelSurfaceView: UIView {
         let topConstraint = contentView.topAnchor.constraint(equalTo: topAnchor, constant: contentInsets.top)
         let leftConstraint = contentView.leftAnchor.constraint(equalTo: leftAnchor, constant: contentInsets.left)
         let rightConstraint = rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: contentInsets.right)
-        let bottomConstraint = bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: contentInsets.bottom)
-        let heightConstraint = contentView.heightAnchor.constraint(equalTo: heightAnchor, constant: -containerTopInset)
+        let heightConstraint = contentView.heightAnchor.constraint(equalTo: heightAnchor, constant: -(containerTopInset + contentInsets.top + contentInsets.bottom))
         NSLayoutConstraint.activate([
             topConstraint,
             leftConstraint,
             rightConstraint,
-            bottomConstraint,
+            heightConstraint,
             ])
         self.contentViewTopConstraint = topConstraint
         self.contentViewLeftConstraint = leftConstraint
         self.contentViewRightConstraint = rightConstraint
-        self.contentViewBottomConstraint = bottomConstraint
+        self.contentViewHeightConstraint = heightConstraint
     }
 }


### PR DESCRIPTION
Fixes #256

![1](https://user-images.githubusercontent.com/1253785/63787320-3bd79580-c8b9-11e9-80d2-7c27c35e5094.png)

I've removed `containerViewTopInsetConstraint` and `containerViewHeightConstraint` in favor of using a bottom constraint.

It's not quite clear what's the purpose of `topInteractionBuffer` and `bottomInteractionBuffer` exactly, but I tried to keep the logic intact.