### PR TITLE
Rename the internal FloatingPanel object for .swiftinterface issue

### DIFF
--- a/Framework/FloatingPanel.xcodeproj/project.pbxproj
+++ b/Framework/FloatingPanel.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		54CDC5D3215B6D5A007D205C /* FloatingPanelSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54CDC5D2215B6D5A007D205C /* FloatingPanelSurfaceView.swift */; };
 		54CDC5D5215B6D8D007D205C /* FloatingPanelBackdropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54CDC5D4215B6D8D007D205C /* FloatingPanelBackdropView.swift */; };
 		54CFBFC3215CD045006B5735 /* FloatingPanelLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54CFBFC2215CD045006B5735 /* FloatingPanelLayout.swift */; };
-		54CFBFC5215CD09C006B5735 /* FloatingPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54CFBFC4215CD09C006B5735 /* FloatingPanel.swift */; };
+		54CFBFC5215CD09C006B5735 /* FloatingPanelCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54CFBFC4215CD09C006B5735 /* FloatingPanelCore.swift */; };
 		54E740CD218AFD67005C1A34 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E740CC218AFD67005C1A34 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
@@ -70,7 +70,7 @@
 		54CDC5D2215B6D5A007D205C /* FloatingPanelSurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelSurfaceView.swift; sourceTree = "<group>"; };
 		54CDC5D4215B6D8D007D205C /* FloatingPanelBackdropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelBackdropView.swift; sourceTree = "<group>"; };
 		54CFBFC2215CD045006B5735 /* FloatingPanelLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelLayout.swift; sourceTree = "<group>"; };
-		54CFBFC4215CD09C006B5735 /* FloatingPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanel.swift; sourceTree = "<group>"; };
+		54CFBFC4215CD09C006B5735 /* FloatingPanelCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelCore.swift; sourceTree = "<group>"; };
 		54E740CA218AFD67005C1A34 /* FloatingPanelTesting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FloatingPanelTesting.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		54E740CC218AFD67005C1A34 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		54E740D8218AFD6A005C1A34 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -129,7 +129,7 @@
 				545DB9C42151169500CA77B8 /* FloatingPanel.h */,
 				545DB9DF21511AC100CA77B8 /* FloatingPanelController.swift */,
 				54352E9521A51A2500CBCA08 /* FloatingPanelTransitioning.swift */,
-				54CFBFC4215CD09C006B5735 /* FloatingPanel.swift */,
+				54CFBFC4215CD09C006B5735 /* FloatingPanelCore.swift */,
 				54CFBFC2215CD045006B5735 /* FloatingPanelLayout.swift */,
 				5450EEE321646DF500135936 /* FloatingPanelBehavior.swift */,
 				54352E9721A521CA00CBCA08 /* FloatingPanelView.swift */,
@@ -311,7 +311,7 @@
 				54CFBFC3215CD045006B5735 /* FloatingPanelLayout.swift in Sources */,
 				54CDC5D5215B6D8D007D205C /* FloatingPanelBackdropView.swift in Sources */,
 				54352E9821A521CA00CBCA08 /* FloatingPanelView.swift in Sources */,
-				54CFBFC5215CD09C006B5735 /* FloatingPanel.swift in Sources */,
+				54CFBFC5215CD09C006B5735 /* FloatingPanelCore.swift in Sources */,
 				54ABD7AF216CCFF7002E6C13 /* Logger.swift in Sources */,
 				545DB9E021511AC100CA77B8 /* FloatingPanelController.swift in Sources */,
 				5450EEE421646DF500135936 /* FloatingPanelBehavior.swift in Sources */,

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -197,7 +197,7 @@ open class FloatingPanelController: UIViewController {
 
     private var _contentViewController: UIViewController?
 
-    private(set) var floatingPanel: FloatingPanel!
+    private(set) var floatingPanel: FloatingPanelCore!
     private var preSafeAreaInsets: UIEdgeInsets = .zero // Capture the latest one
     private var safeAreaInsetsObservation: NSKeyValueObservation?
     private let modalTransition = FloatingPanelModalTransition()
@@ -220,7 +220,7 @@ open class FloatingPanelController: UIViewController {
         modalPresentationStyle = .custom
         transitioningDelegate = modalTransition
 
-        floatingPanel = FloatingPanel(self,
+        floatingPanel = FloatingPanelCore(self,
                                       layout: fetchLayout(for: self.traitCollection),
                                       behavior: fetchBehavior(for: self.traitCollection))
     }

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -229,7 +229,7 @@ open class FloatingPanelController: UIViewController {
         floatingPanel.layoutAdapter.layout = fetchLayout(for: traitCollection)
         floatingPanel.behavior = fetchBehavior(for: self.traitCollection)
     }
-    
+
     // MARK:- Overrides
 
     /// Creates the view that the controller manages.

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -62,7 +62,7 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
 
         surfaceView = FloatingPanelSurfaceView()
         surfaceView.backgroundColor = .white
-        
+
         backdropView = FloatingPanelBackdropView()
         backdropView.backgroundColor = .black
         backdropView.alpha = 0.0
@@ -204,7 +204,7 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
             let surfaceFrame = surfaceView.layer.presentation()?.frame ?? surfaceView.frame
             let surfaceY = surfaceFrame.minY
             let adapterY = layoutAdapter.positionY(for: state)
-            
+
             return abs(surfaceY - adapterY) < (1.0 / surfaceView.traitCollection.displayScale)
         }
     }
@@ -586,9 +586,9 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
         let currentY = surfaceView.frame.minY
         let targetPosition = self.targetPosition(from: currentY, with: velocity)
         let distance = self.distance(to: targetPosition)
-        
+
         endInteraction(for: targetPosition)
-        
+
         if isRemovalInteractionEnabled, isBottomState {
             let velocityVector = (distance != 0) ? CGVector(dx: 0, dy: min(velocity.y/distance, behavior.removalVelocity)) : .zero
             // `velocityVector` will be replaced by just a velocity(not vector) when FloatingPanelRemovalInteraction will be added.

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -8,7 +8,7 @@ import UIKit.UIGestureRecognizerSubclass // For Xcode 9.4.1
 ///
 /// FloatingPanel presentation model
 ///
-class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
+class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
     // MUST be a weak reference to prevent UI freeze on the presentation modally
     weak var viewcontroller: FloatingPanelController?
 
@@ -890,7 +890,7 @@ class FloatingPanel: NSObject, UIGestureRecognizerDelegate {
 }
 
 class FloatingPanelPanGestureRecognizer: UIPanGestureRecognizer {
-    fileprivate weak var floatingPanel: FloatingPanel?
+    fileprivate weak var floatingPanel: FloatingPanelCore?
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
         if floatingPanel?.animator != nil {
@@ -902,7 +902,7 @@ class FloatingPanelPanGestureRecognizer: UIPanGestureRecognizer {
             return super.delegate
         }
         set {
-            guard newValue is FloatingPanel else {
+            guard newValue is FloatingPanelCore else {
                 let exception = NSException(name: .invalidArgumentException,
                                             reason: "FloatingPanelController's built-in pan gesture recognizer must have its controller as its delegate.",
                                             userInfo: nil)

--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -94,7 +94,7 @@ public protocol FloatingPanelLayout: class {
     func backdropAlphaFor(position: FloatingPanelPosition) -> CGFloat
 
     var positionReference: FloatingPanelLayoutReference { get }
-    
+
 }
 
 public extension FloatingPanelLayout {

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -34,7 +34,7 @@ public class FloatingPanelSurfaceView: UIView {
 
     /// A root view of a content view controller
     public weak var contentView: UIView!
-    
+
     /// The content insets specifying the insets around the content view.
     public var contentInsets: UIEdgeInsets = .zero {
         didSet {
@@ -101,7 +101,7 @@ public class FloatingPanelSurfaceView: UIView {
     private lazy var containerViewHeightConstraint = containerView.heightAnchor.constraint(equalTo: heightAnchor, multiplier: 1.0)
     private lazy var containerViewLeftConstraint = containerView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0.0)
     private lazy var containerViewRightConstraint = containerView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0.0)
-    
+
     /// The content view top constraint
     private var contentViewTopConstraint: NSLayoutConstraint?
     /// The content view left constraint

--- a/Framework/Tests/FloatingPanelLayoutTests.swift
+++ b/Framework/Tests/FloatingPanelLayoutTests.swift
@@ -238,7 +238,7 @@ class FloatingPanelLayoutTests: XCTestCase {
 }
 
 private typealias LayoutSegmentTestParameter = (UInt, pos: CGFloat, forwardY: Bool, lower: FloatingPanelPosition?, upper: FloatingPanelPosition?)
-private func assertLayoutSegment(_ floatingPanel: FloatingPanel, with params: [LayoutSegmentTestParameter]) {
+private func assertLayoutSegment(_ floatingPanel: FloatingPanelCore, with params: [LayoutSegmentTestParameter]) {
     params.forEach { (line, pos, forwardY, lowr, upper) in
         let segument = floatingPanel.layoutAdapter.segument(at: pos, forward: forwardY)
         XCTAssertEqual(segument.lower, lowr, line: line)

--- a/Framework/Tests/FloatingPanelTests.swift
+++ b/Framework/Tests/FloatingPanelTests.swift
@@ -523,7 +523,7 @@ private class FloatingPanelLayout3Positions: FloatingPanelTestLayout {
 }
 
 private typealias TestParameter = (UInt, CGFloat,CGPoint, FloatingPanelPosition)
-private func assertTargetPosition(_ floatingPanel: FloatingPanel, with params: [TestParameter]) {
+private func assertTargetPosition(_ floatingPanel: FloatingPanelCore, with params: [TestParameter]) {
     params.forEach { (line, pos, velocity, result) in
         floatingPanel.surfaceView.frame.origin.y = pos
         XCTAssertEqual(floatingPanel.targetPosition(from: pos, with: velocity), result, line: line)


### PR DESCRIPTION
"'FloatingPanel' is not a member type of 'FloatingPanel'" error happens when the lib is built on Xcode 11 series using 'Build Library for Distribution`.

To fix the error, the lib has to rename the internal object named as `FloatingPanel` according the below comment.

> It's not your fault; it's a longstanding bug/limitation in Swift that if you have a type and a framework with the same name, the name is always assumed to refer to the type. brentdax is looking at some alternate ways to provide a module name in Pitch: Fully qualified name syntax that the module interface generator will be able to use; for now, though, you can work around this issue by renaming either your framework or the type in it. :-(

See https://forums.swift.org/t/frameworkname-is-not-a-member-type-of-frameworkname-errors-inside-swiftinterface/28962 for details.