### PR TITLE
[WIP] Add a scroll observer

### DIFF
--- a/Framework/Sources/UIExtensions.swift
+++ b/Framework/Sources/UIExtensions.swift
@@ -136,6 +136,9 @@ extension CGPoint {
         return CGPoint(x: CGFloat.nan,
                        y: CGFloat.nan)
     }
+    static func -(lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+        return CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+    }
 }
 
 extension UITraitCollection {


### PR DESCRIPTION
This PR improves `FloatingPanel.allowScrollPanGesture(at:)` logic using `ScrollObserver`which handles a scroll gesture context.

`FloatingPanel.allowScrollPanGesture(at:)` returns `false` once a user bounces a scroll content at the top.