### PR TITLE
Fix a panel's move-up while dragging it down

### DIFF
--- a/Examples/Maps/Maps/ViewController.swift
+++ b/Examples/Maps/Maps/ViewController.swift
@@ -178,7 +178,7 @@ class SearchPanelViewController: UIViewController, UITableViewDataSource, UITabl
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 2
+        return 100
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -189,12 +189,10 @@ class SearchPanelViewController: UIViewController, UITableViewDataSource, UITabl
                 cell.iconImageView.image = UIImage(named: "mark")
                 cell.titleLabel.text = "Marked Location"
                 cell.subTitleLabel.text = "Golden Gate Bridge, San Francisco"
-            case 1:
+            default:
                 cell.iconImageView.image = UIImage(named: "like")
                 cell.titleLabel.text = "Favorites"
                 cell.subTitleLabel.text = "0 Places"
-            default:
-                break
             }
         }
         return cell

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -234,6 +234,9 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
                 scrollGestureRecognizers.contains(otherGestureRecognizer) {
                 switch otherGestureRecognizer {
                 case scrollView.panGestureRecognizer:
+                    if grabberAreaFrame.contains(gestureRecognizer.location(in: gestureRecognizer.view)) {
+                        return false
+                    }
                     let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
                     return allowScrollPanGesture(at: CGPoint(x: 0.0, y: offset))
                 default:
@@ -677,7 +680,7 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
 
         initialFrame = surfaceView.frame
         if state == layoutAdapter.topMostState, let scrollView = scrollView {
-            if grabberAreaFrame.contains(location) {
+            if grabberAreaFrame.contains(location) || scrollView.isTracking == false {
                 initialScrollOffset = scrollView.contentOffset
             } else {
                 initialScrollOffset = scrollView.contentOffsetZero

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -680,9 +680,12 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
             if grabberAreaFrame.contains(location) {
                 initialScrollOffset = scrollView.contentOffset
             } else {
-                // Fit the surface bounds to a scroll offset content by startInteraction(at:offset:)
-                offset = CGPoint(x: -scrollView.contentOffset.x, y: -scrollView.contentOffset.y)
                 initialScrollOffset = scrollView.contentOffsetZero
+                // Fit the surface bounds to a scroll offset content by startInteraction(at:offset:)
+                let scrollOffsetY = (scrollView.contentOffset.y - scrollView.contentOffsetZero.y)
+                if scrollOffsetY < 0 {
+                    offset = CGPoint(x: -scrollView.contentOffset.x, y: -scrollOffsetY)
+                }
             }
             log.debug("initial scroll offset --", initialScrollOffset)
         }


### PR DESCRIPTION
This issue is that a panel sometimes moved up in dragging it down if content offset of the tracking scroll view in a content view controller was greater than its top interaction buffer.

Ref. #293