### PR TITLE
Add floatingPanel(_:contentOffsetForPinning:) delegate method

### DIFF
--- a/Examples/Samples/Sources/Base.lproj/Main.storyboard
+++ b/Examples/Samples/Sources/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RoN-h0-uBD">
-    <device id="retina5_9" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RoN-h0-uBD">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,7 +11,7 @@
         <!--Navigation Controller-->
         <scene sceneID="Cjh-iX-VQw">
             <objects>
-                <navigationController id="RoN-h0-uBD" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="RootNavigationController" id="RoN-h0-uBD" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="hNW-5m-Omi">
                         <rect key="frame" x="0.0" y="44" width="375" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -26,6 +26,7 @@ class SampleListViewController: UIViewController {
         case showIntrinsicView
         case showContentInset
         case showContainerMargins
+        case showNavigationController
 
         var name: String {
             switch self {
@@ -42,6 +43,7 @@ class SampleListViewController: UIViewController {
             case .showIntrinsicView: return "Show Intrinsic View"
             case .showContentInset: return "Show with ContentInset"
             case .showContainerMargins: return "Show with ContainerMargins"
+            case .showNavigationController: return "Show Navigation Controller"
             }
         }
 
@@ -60,6 +62,7 @@ class SampleListViewController: UIViewController {
             case .showIntrinsicView: return "IntrinsicViewController"
             case .showContentInset: return nil
             case .showContainerMargins: return nil
+            case .showNavigationController: return "RootNavigationController"
             }
         }
     }
@@ -80,6 +83,7 @@ class SampleListViewController: UIViewController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+        automaticallyAdjustsScrollViewInsets = false
 
         let searchController = UISearchController(searchResultsController: nil)
         if #available(iOS 11.0, *) {
@@ -92,11 +96,14 @@ class SampleListViewController: UIViewController {
 
         let contentVC = DebugTableViewController()
         addMainPanel(with: contentVC)
+
+        var insets = UIEdgeInsets.zero
+        insets.bottom += 69.0
+        tableView.contentInset = insets
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
         if #available(iOS 11.0, *) {
             if let observation = navigationController?.navigationBar.observe(\.prefersLargeTitles, changeHandler: { (bar, _) in
                 self.tableView.reloadData()
@@ -143,6 +150,8 @@ class SampleListViewController: UIViewController {
 
             let backdropTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackdrop(tapGesture:)))
             mainPanelVC.backdropView.addGestureRecognizer(backdropTapGesture)
+        case .showNavigationController:
+            mainPanelVC.contentInsetAdjustmentBehavior = .never
         default:
             break
         }
@@ -160,6 +169,11 @@ class SampleListViewController: UIViewController {
             mainPanelVC.track(scrollView: contentVC.tableView)
         case let contentVC as NestedScrollViewController:
             mainPanelVC.track(scrollView: contentVC.scrollView)
+        case let navVC as UINavigationController:
+            if let rootVC = (navVC.topViewController as? SampleListViewController) {
+                rootVC.loadViewIfNeeded()
+                mainPanelVC.track(scrollView: rootVC.tableView)
+            }
         default:
             break
         }
@@ -368,6 +382,17 @@ extension SampleListViewController: UITableViewDelegate {
 }
 
 extension SampleListViewController: FloatingPanelControllerDelegate {
+    func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint {
+        if currentMenu == .showNavigationController {
+            if #available(iOSApplicationExtension 11.0, *) {
+                return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top - 148.0)
+            } else {
+                return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top)
+            }
+        }
+        return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top)
+    }
+
     func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {
         if vc == settingsPanelVC {
             return IntrinsicPanelLayout()
@@ -662,6 +687,9 @@ class DebugTableViewController: InspectableViewController {
             ])
         tableView.dataSource = self
         tableView.delegate = self
+        if #available(iOS 11.0, *) {
+            tableView.contentInsetAdjustmentBehavior = .never
+        }
         self.tableView = tableView
 
         let stackView = UIStackView()

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -383,12 +383,9 @@ extension SampleListViewController: UITableViewDelegate {
 
 extension SampleListViewController: FloatingPanelControllerDelegate {
     func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint {
-        if currentMenu == .showNavigationController {
-            if #available(iOSApplicationExtension 11.0, *) {
-                return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top - 148.0)
-            } else {
-                return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top)
-            }
+        if currentMenu == .showNavigationController, #available(iOSApplicationExtension 11.0, *) {
+            // 148.0 is the SafeArea's top value for a navigation bar with a large title.
+            return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top - 148.0)
         }
         return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top)
     }

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -126,6 +126,7 @@ class SampleListViewController: UIViewController {
         // Initialize FloatingPanelController
         mainPanelVC = FloatingPanelController()
         mainPanelVC.delegate = self
+        mainPanelVC.contentInsetAdjustmentBehavior = .always
 
         // Initialize FloatingPanelController and add the view
         mainPanelVC.surfaceView.cornerRadius = 6.0

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -37,6 +37,8 @@ public protocol FloatingPanelControllerDelegate: class {
     ///
     /// By default, any tap and long gesture recognizers are allowed to recognize gestures simultaneously.
     func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool
+
+    func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint
 }
 
 public extension FloatingPanelControllerDelegate {
@@ -61,6 +63,9 @@ public extension FloatingPanelControllerDelegate {
 
     func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool {
         return false
+    }
+    func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint {
+        return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top)
     }
 }
 

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -393,13 +393,18 @@ open class FloatingPanelController: UIViewController {
     private func activateLayout() {
         floatingPanel.layoutAdapter.prepareLayout(in: self)
 
-        // preserve the current content offset
-        let contentOffset = scrollView?.contentOffset
+        // preserve the current content offset if contentInsetAdjustmentBehavior is `.always`
+        var contentOffset: CGPoint?
+        if contentInsetAdjustmentBehavior == .always {
+            contentOffset = scrollView?.contentOffset
+        }
 
         floatingPanel.layoutAdapter.updateHeight()
         floatingPanel.layoutAdapter.activateLayout(of: floatingPanel.state)
 
-        scrollView?.contentOffset = contentOffset ?? .zero
+        if let contentOffset = contentOffset {
+            scrollView?.contentOffset = contentOffset
+        }
     }
 
     // MARK: - Container view controller interface

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -38,11 +38,11 @@ public protocol FloatingPanelControllerDelegate: class {
     /// By default, any tap and long gesture recognizers are allowed to recognize gestures simultaneously.
     func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool
 
-    /// Asks the delegate for the content offset of a tracked scroll view pinned when a panel moves
+    /// Asks the delegate for a content offset of the tracked scroll view to be pinned when a floating panel moves
     ///
     /// If you do not implement this method, the controller uses a value of the content offset plus the content insets
-    /// of a tracked scroll view. Your implementation of this method can return a value for a navigation bar with a large
-    /// title.
+    /// of the tracked scroll view. Your implementation of this method can return a value for a navigation bar with a large
+    /// title, for example.
     ///
     /// This method will not be called if the controller doesn't track any scroll view.
     func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -38,6 +38,13 @@ public protocol FloatingPanelControllerDelegate: class {
     /// By default, any tap and long gesture recognizers are allowed to recognize gestures simultaneously.
     func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool
 
+    /// Asks the delegate for the content offset of a tracked scroll view pinned when a panel moves
+    ///
+    /// If you do not implement this method, the controller uses a value of the content offset plus the content insets
+    /// of a tracked scroll view. Your implementation of this method can return a value for a navigation bar with a large
+    /// title.
+    ///
+    /// This method will not be called if the controller doesn't track any scroll view.
     func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint
 }
 

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -210,7 +210,6 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
     }
 
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        guard gestureRecognizer == panGestureRecognizer else { return false }
         /* log.debug("shouldBeRequiredToFailBy", otherGestureRecognizer) */
         return false
     }

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -237,8 +237,7 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
                     if grabberAreaFrame.contains(gestureRecognizer.location(in: gestureRecognizer.view)) {
                         return false
                     }
-                    let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
-                    return allowScrollPanGesture(at: CGPoint(x: 0.0, y: offset))
+                    return allowScrollPanGesture(for: scrollView)
                 default:
                     return false
                 }
@@ -293,14 +292,13 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
             let surfaceMinY = surfaceView.presentationFrame.minY
             let adapterTopY = layoutAdapter.topY
             let belowTop = surfaceMinY > (adapterTopY + (1.0 / surfaceView.traitCollection.displayScale))
-            let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
-
             log.debug("scroll gesture(\(state):\(panGesture.state)) --",
                 "belowTop = \(belowTop),",
                 "interactionInProgress = \(interactionInProgress),",
-                "scroll offset = \(offset),",
+                "scroll offset = \(scrollView.contentOffset.y),",
                 "location = \(location.y), velocity = \(velocity.y)")
 
+            let offset = scrollView.contentOffset.y - contentOrigin(of: scrollView).y
 
             if belowTop {
                 // Scroll offset pinning
@@ -343,11 +341,11 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
                 } else {
                     if state == layoutAdapter.topMostState {
                         // Hide a scroll indicator just before starting an interaction by swiping a panel down.
-                        if velocity.y > 0, !allowScrollPanGesture(at: CGPoint(x: 0.0, y: offset)) {
+                        if velocity.y > 0, !allowScrollPanGesture(for: scrollView) {
                             lockScrollView()
                         }
                         // Show a scroll indicator when an animation is interrupted at the top and content is scrolled up
-                        if velocity.y < 0, allowScrollPanGesture(at: CGPoint(x: 0.0, y: offset)) {
+                        if velocity.y < 0, allowScrollPanGesture(for: scrollView) {
                             unlockScrollView()
                         }
 
@@ -457,7 +455,7 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
             return false
         }
 
-        let offset = scrollView.contentOffset.y - scrollView.contentOffsetZero.y
+        let offset = scrollView.contentOffset.y - contentOrigin(of: scrollView).y
         // The zero offset must be excluded because the offset is usually zero
         // after a panel moves from half/tip to full.
         if  offset > 0.0 {
@@ -686,9 +684,9 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
             if grabberAreaFrame.contains(location) || scrollView.isTracking == false {
                 initialScrollOffset = scrollView.contentOffset
             } else {
-                initialScrollOffset = scrollView.contentOffsetZero
+                initialScrollOffset = contentOrigin(of: scrollView)
                 // Fit the surface bounds to a scroll offset content by startInteraction(at:offset:)
-                let scrollOffsetY = (scrollView.contentOffset.y - scrollView.contentOffsetZero.y)
+                let scrollOffsetY = (scrollView.contentOffset.y - contentOrigin(of: scrollView).y)
                 if scrollOffsetY < 0 {
                     offset = CGPoint(x: -scrollView.contentOffset.x, y: -scrollOffsetY)
                 }
@@ -889,7 +887,15 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
         scrollView?.setContentOffset(contentOffset, animated: false)
     }
 
-    private func allowScrollPanGesture(at contentOffset: CGPoint) -> Bool {
+    private func contentOrigin(of scrollView: UIScrollView) -> CGPoint {
+        if let vc = viewcontroller, let origin = vc.delegate?.foatingPanel(vc, contentOffsetForPinning: scrollView) {
+            return origin
+        }
+        return CGPoint(x: 0.0, y: 0.0 - scrollView.contentInset.top)
+    }
+
+    private func allowScrollPanGesture(for scrollView: UIScrollView) -> Bool {
+        let contentOffset = scrollView.contentOffset - contentOrigin(of: scrollView)
         if state == layoutAdapter.topMostState {
             return contentOffset.y <= -30.0 || contentOffset.y > 0
         }

--- a/Framework/Sources/UIExtensions.swift
+++ b/Framework/Sources/UIExtensions.swift
@@ -114,9 +114,6 @@ extension UIGestureRecognizerState: CustomDebugStringConvertible {
 #endif
 
 extension UIScrollView {
-    var contentOffsetZero: CGPoint {
-        return CGPoint(x: 0.0, y: 0.0 - contentInset.top)
-    }
     var isLocked: Bool {
         return !showsVerticalScrollIndicator && !bounces &&  isDirectionalLockEnabled
     }
@@ -133,8 +130,10 @@ extension UISpringTimingParameters {
 
 extension CGPoint {
     static var nan: CGPoint {
-        return CGPoint(x: CGFloat.nan,
-                       y: CGFloat.nan)
+        return CGPoint(x: CGFloat.nan, y: CGFloat.nan)
+    }
+    static func - (left: CGPoint, right: CGPoint) -> CGPoint {
+        return CGPoint(x: left.x - right.x, y: left.y - right.y)
     }
 }
 


### PR DESCRIPTION
FloatingPanelController asks the delegate for the content offset of a tracked scroll view pinned when a panel moves.

If you do not implement this method, the controller uses a value of the content offset plus the content insets. This method will not be called if the controller doesn't track any scroll view.

The reason why it's added is because a visual content origin of a scroll view is not always equal to its content offset plus its content insets. One of the cases is issue #304.

You can fix #304 by returning a value for a navigation bar with a large title as below.
```
return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top - 148.0)
```

See also "Show Navigation Controller" in the Samples app.