### PR TITLE
ignore .swiftpm/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ xcuserdata/
 *.dSYM.zip
 *.dSYM
 
+## Swift Package Manager Specific
+.swiftpm/
+
 ## Playgrounds
 timeline.xctimeline
 playground.xcworkspace


### PR DESCRIPTION
When opening the FloatingPanel package, this folder is created. 

This folder contains what can be considered the SwiftPM version of "Xcode derived data" folder, therefore I suggest it to be ignored.