### PR TITLE
Fix api typo

### DIFF
--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -387,7 +387,7 @@ extension SampleListViewController: UITableViewDelegate {
 }
 
 extension SampleListViewController: FloatingPanelControllerDelegate {
-    func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint {
+    func floatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint {
         if currentMenu == .showNavigationController, #available(iOSApplicationExtension 11.0, *) {
             // 148.0 is the SafeArea's top value for a navigation bar with a large title.
             return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top - 148.0)

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -45,7 +45,7 @@ public protocol FloatingPanelControllerDelegate: class {
     /// title, for example.
     ///
     /// This method will not be called if the controller doesn't track any scroll view.
-    func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint
+    func floatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint
 }
 
 public extension FloatingPanelControllerDelegate {
@@ -71,7 +71,7 @@ public extension FloatingPanelControllerDelegate {
     func floatingPanel(_ vc: FloatingPanelController, shouldRecognizeSimultaneouslyWith gestureRecognizer: UIGestureRecognizer) -> Bool {
         return false
     }
-    func foatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint {
+    func floatingPanel(_ vc: FloatingPanelController, contentOffsetForPinning trackedScrollView: UIScrollView) -> CGPoint {
         return CGPoint(x: 0.0, y: 0.0 - trackedScrollView.contentInset.top)
     }
 }

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -905,7 +905,7 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
     }
 
     private func contentOrigin(of scrollView: UIScrollView) -> CGPoint {
-        if let vc = viewcontroller, let origin = vc.delegate?.foatingPanel(vc, contentOffsetForPinning: scrollView) {
+        if let vc = viewcontroller, let origin = vc.delegate?.floatingPanel(vc, contentOffsetForPinning: scrollView) {
             return origin
         }
         return CGPoint(x: 0.0, y: 0.0 - scrollView.contentInset.top)


### PR DESCRIPTION
This pr fixes the new api name from `foatingPanel` to `floatingPanel`