### PR TITLE
Release 1.7.4

### DIFF
--- a/FloatingPanel.podspec
+++ b/FloatingPanel.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                = "FloatingPanel"
-  s.version             = "1.7.3"
+  s.version             = "1.7.4"
   s.summary             = "FloatingPanel is a clean and easy-to-use UI component of a floating panel interface."
   s.description         = <<-DESC
 FloatingPanel is a clean and easy-to-use UI component for a new interface introduced in Apple Maps, Shortcuts and Stocks app.

--- a/Framework/Sources/Info.plist
+++ b/Framework/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.3</string>
+	<string>1.7.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
1.7.3 has a mistake of API name. So I release 1.7.4 for the hot fix.
- [x] Release note
- [x] Push it cocoa pods and delete v1.7.3
