### PR TITLE
Show panel back to the last position before hiding it

### DIFF
--- a/Framework/Sources/FloatingPanelBehavior.swift
+++ b/Framework/Sources/FloatingPanelBehavior.swift
@@ -68,6 +68,12 @@ public protocol FloatingPanelBehavior {
     ///
     /// This method allows the behavior to activate the rubber band effect to a given edge of the surface view. By default, the effect is disabled.
     func allowsRubberBanding(for edge: UIRectEdge) -> Bool
+    
+    /// Decide if showing the panel should use the last position before hiding if possible.
+    /// If false, it will always use the layout initial position.
+    ///
+    /// Default is false, which will always use the initial position.
+    var showToLastPositionIfPossible: Bool { get }
 }
 
 public extension FloatingPanelBehavior {
@@ -120,6 +126,10 @@ public extension FloatingPanelBehavior {
     }
 
     func allowsRubberBanding(for edge: UIRectEdge) -> Bool {
+        return false
+    }
+    
+    var showToLastPositionIfPossible: Bool {
         return false
     }
 }

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -410,7 +410,7 @@ open class FloatingPanelController: UIViewController {
     // MARK: - Container view controller interface
 
     /// Shows the surface view at the initial position defined by the current layout
-    public func show(animated: Bool = false, completion: (() -> Void)? = nil) {
+    public func show(to position: FloatingPanelPosition? = nil, animated: Bool = false, completion: (() -> Void)? = nil) {
         // Must apply the current layout here
         reloadLayout(for: traitCollection)
         activateLayout()
@@ -431,9 +431,14 @@ open class FloatingPanelController: UIViewController {
             // Instead, update(safeAreaInsets:) is called at `viewDidLayoutSubviews()`
         }
 
-        move(to: floatingPanel.layoutAdapter.layout.initialPosition,
-             animated: animated,
-             completion: completion)
+        let layout = floatingPanel.layoutAdapter.layout
+        var showingPosition = layout.initialPosition
+        if let position = position {
+            precondition(layout.supportedPositions.contains(position))
+            showingPosition = position
+        }
+        
+        move(to: showingPosition, animated: animated, completion: completion)
     }
 
     /// Hides the surface view to the hidden position


### PR DESCRIPTION
Hi 👋,
I met the use case for a project:
The idea is to add a new behaviour allowing to **show the panel back to the last position it was right before hiding it**, instead of always use the layout initial position.

Let me know if some improvements are needed, or if this is not a welcome behaviour, which is fine 😉

Paul