### PR TITLE
Enable the removal interaction at any positions upon the conditions

### DIFF
--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -1355,13 +1355,24 @@ final class MultiPanelController: FloatingPanelController, FloatingPanelControll
 
     private final class FirstViewLayout: FloatingPanelLayout {
         let initialPosition: FloatingPanelPosition = .full
-        let supportedPositions: Set<FloatingPanelPosition> = [.full]
+        let supportedPositions: Set<FloatingPanelPosition> = [.full, .half]
         func insetFor(position: FloatingPanelPosition) -> CGFloat? {
             switch position {
             case .full: return 40.0
+            case .half: return 200.0
             default: return nil
             }
         }
+    }
+
+    private final class FirstViewBehavior: FloatingPanelBehavior {
+        func shouldProjectMomentum(_ fpc: FloatingPanelController, for proposedTargetPosition: FloatingPanelPosition) -> Bool {
+            return true
+        }
+    }
+
+    func floatingPanel(_ vc: FloatingPanelController, behaviorFor newCollection: UITraitCollection) -> FloatingPanelBehavior? {
+        return FirstViewBehavior()
     }
 
     func floatingPanel(_ vc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout? {

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -617,7 +617,7 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
 
         endInteraction(for: targetPosition)
 
-        if isRemovalInteractionEnabled, isBottomState {
+        if isRemovalInteractionEnabled {
             let velocityVector: CGVector
             if distance == 0 {
                 velocityVector = .zero
@@ -627,12 +627,14 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
             }
             // `velocityVector` will be replaced by just a velocity(not vector) when FloatingPanelRemovalInteraction will be added.
             if shouldStartRemovalAnimation(with: velocityVector), let vc = viewcontroller {
-                vc.delegate?.floatingPanelDidEndDraggingToRemove(vc, withVelocity: velocity)
-                let animationVector = CGVector(dx: abs(velocityVector.dx), dy: abs(velocityVector.dy))
-                startRemovalAnimation(vc, with: animationVector) { [weak self] in
-                    self?.finishRemovalAnimation()
+                if behavior.shouldProjectMomentum(vc, for: targetPosition) || isBottomState {
+                    vc.delegate?.floatingPanelDidEndDraggingToRemove(vc, withVelocity: velocity)
+                    let animationVector = CGVector(dx: abs(velocityVector.dx), dy: abs(velocityVector.dy))
+                    startRemovalAnimation(vc, with: animationVector) { [weak self] in
+                        self?.finishRemovalAnimation()
+                    }
+                    return
                 }
-                return
             }
         }
 


### PR DESCRIPTION
If a library consumer allows a panel projectable movement with the
FloatingPanelBehavior object, the panel is able to invoke the removal
interaction when the next moving position projected the momentum is
hidden.

Resolve #334 