### PR TITLE
Fix an invalid indicator insets of the tracking scroll view

### DIFF
--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -371,7 +371,6 @@ open class FloatingPanelController: UIViewController {
         switch contentInsetAdjustmentBehavior {
         case .always:
             scrollView?.contentInset = adjustedContentInsets
-            scrollView?.scrollIndicatorInsets = adjustedContentInsets
         default:
             break
         }


### PR DESCRIPTION
Fix an invalid indicator insets of the tracking scroll view if `FloatingPanelController.contentInsetAdjustmentBehavior` is set to true.