### PR TITLE
fix {top,bottom} constant's boundary in updating panel interactively

### DIFF
--- a/Framework/Sources/FloatingPanelLayout.swift
+++ b/Framework/Sources/FloatingPanelLayout.swift
@@ -457,7 +457,7 @@ class FloatingPanelLayoutAdapter {
             case .fromSuperview:
                 ret = topY
             }
-            return max(ret, 0.0) // The top boundary is equal to the related topAnchor.
+            return ret
         }()
         let bottomMostConst: CGFloat = {
             var ret: CGFloat = 0.0
@@ -468,7 +468,7 @@ class FloatingPanelLayoutAdapter {
             case .fromSuperview:
                 ret = _bottomY
             }
-            return min(ret, surfaceView.superview!.bounds.height)
+            return ret
         }()
         let minConst = allowsTopBuffer ? topMostConst - layout.topInteractionBuffer : topMostConst
         let maxConst = bottomMostConst + layout.bottomInteractionBuffer

--- a/Framework/Tests/FloatingPanelLayoutTests.swift
+++ b/Framework/Tests/FloatingPanelLayoutTests.swift
@@ -195,6 +195,43 @@ class FloatingPanelLayoutTests: XCTestCase {
         fpc.floatingPanel.layoutAdapter.endInteraction(at: fpc.position)
     }
 
+    func test_updateInteractiveTopConstraintWithMinusInsets() {
+        class FloatingPanelLayoutMinusInsets: FloatingPanelTestLayout {
+            let initialPosition: FloatingPanelPosition = .full
+            let supportedPositions: Set<FloatingPanelPosition> = [.tip, .full]
+            func insetFor(position: FloatingPanelPosition) -> CGFloat? {
+                switch position {
+                case .full, .tip: return -200
+                default: return nil
+                }
+            }
+        }
+        let delegate = FloatingPanelTestDelegate()
+        delegate.layout = FloatingPanelLayoutMinusInsets()
+        fpc.delegate = delegate
+        fpc.showForTest()
+        fpc.floatingPanel.layoutAdapter.startInteraction(at: fpc.position)
+
+        let fullPos = fpc.originYOfSurface(for: .full)
+        let tipPos = fpc.originYOfSurface(for: .tip)
+        let current = fpc.surfaceView.frame.minY
+
+        var next: CGFloat
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: -100.0, allowsTopBuffer: false, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, current)
+
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: -100.0, allowsTopBuffer: true, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, fullPos - fpc.layout.topInteractionBuffer)
+
+        fpc.floatingPanel.layoutAdapter.updateInteractiveTopConstraint(diff: tipPos - fullPos + 100.0, allowsTopBuffer: true, with: fpc.behavior)
+        next = fpc.surfaceView.frame.minY
+        XCTAssertEqual(next, tipPos + fpc.layout.bottomInteractionBuffer)
+
+        fpc.floatingPanel.layoutAdapter.endInteraction(at: fpc.position)
+    }
+
     func test_positionReference() {
         fpc = CustomSafeAreaFloatingPanelController()
         fpc.loadViewIfNeeded()


### PR DESCRIPTION
Because {top,bottom}Y can be {less,more} than the SafeArea/Superview bounds,
if a minus value is set to the inset for {top,bottom} most position.

fix #349 