### PR TITLE
Fix the panel behavior in a sheet modal

### DIFF
--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -19,6 +19,7 @@ class SampleListViewController: UIViewController {
         case showModal
         case showPanelModal
         case showMultiPanelModal
+        case showPanelInSheetModal
         case showTabBar
         case showPageView
         case showPageContentView
@@ -37,6 +38,7 @@ class SampleListViewController: UIViewController {
             case .showModal: return "Show Modal"
             case .showPanelModal: return "Show Panel Modal"
             case .showMultiPanelModal: return "Show Multi Panel Modal"
+            case .showPanelInSheetModal: return "Show Panel in Sheet Modal"
             case .showTabBar: return "Show Tab Bar"
             case .showPageView: return "Show Page View"
             case .showPageContentView: return "Show Page Content View"
@@ -56,6 +58,7 @@ class SampleListViewController: UIViewController {
             case .showDetail: return "DetailViewController"
             case .showModal: return "ModalViewController"
             case .showMultiPanelModal: return nil
+            case .showPanelInSheetModal: return nil
             case .showPanelModal: return nil
             case .showTabBar: return "TabBarViewController"
             case .showPageView: return nil
@@ -350,6 +353,20 @@ extension SampleListViewController: UITableViewDelegate {
             let fpc = MultiPanelController()
             self.present(fpc, animated: true, completion: nil)
 
+        case .showPanelInSheetModal:
+            let fpc = FloatingPanelController()
+            let contentVC = UIViewController()
+            fpc.set(contentViewController: contentVC)
+            fpc.delegate = self
+
+            fpc.surfaceView.cornerRadius = 38.5
+            fpc.surfaceView.shadowHidden = false
+            fpc.isRemovalInteractionEnabled = true
+
+            let mvc = UIViewController()
+            mvc.view.backgroundColor = UIColor(displayP3Red: 2/255, green: 184/255, blue: 117/255, alpha: 1.0)
+            fpc.addPanel(toParent: mvc)
+            self.present(mvc, animated: true, completion: nil)
         case .showContentInset:
             let contentViewController = UIViewController()
             contentViewController.view.backgroundColor = .green

--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -882,8 +882,7 @@ class ModalViewController: UIViewController, FloatingPanelControllerDelegate {
 
     var isNewlayout: Bool = false
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidLoad() {
         // Initialize FloatingPanelController
         fpc = FloatingPanelController()
         fpc.delegate = self
@@ -903,8 +902,8 @@ class ModalViewController: UIViewController, FloatingPanelControllerDelegate {
         fpc.addPanel(toParent: self, belowView: safeAreaView)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         //  Remove FloatingPanel from a view
         fpc.removePanelFromParent(animated: false)
     }
@@ -965,20 +964,15 @@ class TabBarContentViewController: UIViewController {
             }
         }
     }
-    var fpc: FloatingPanelController!
+    lazy var fpc = FloatingPanelController()
     var consoleVC: DebugTextViewController!
 
     var threeLayout: ThreeTabBarPanelLayout!
     var tab3Mode: Tab3Mode = .changeAutoLayout
     var switcherLabel: UILabel!
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        // Initialize FloatingPanelController
-        fpc = FloatingPanelController()
+    override func viewDidLoad() {
         fpc.delegate = self
-
-        // Initialize FloatingPanelController and add the view
         fpc.surfaceView.cornerRadius = 6.0
         fpc.surfaceView.shadowHidden = false
 
@@ -1026,12 +1020,6 @@ class TabBarContentViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         fpc.updateLayout()
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        //  Remove FloatingPanel from a view
-        fpc.removePanelFromParent(animated: false)
     }
 
     // MARK: - Action

--- a/Framework/Sources/FloatingPanelController.swift
+++ b/Framework/Sources/FloatingPanelController.swift
@@ -670,7 +670,8 @@ public extension UIViewController {
         }
         // Call dismiss(animated:completion:) to FloatingPanelController directly
         if let fpc = self as? FloatingPanelController {
-            if fpc.presentingViewController != nil {
+            // When a panel is presented modally and it's not a child view controller of the presented view controller.
+            if fpc.presentingViewController != nil, fpc.parent == nil {
                 self.fp_original_dismiss(animated: flag, completion: completion)
             } else {
                 fpc.removePanelFromParent(animated: flag, completion: completion)

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -199,11 +199,6 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
              is UIRotationGestureRecognizer,
              is UIScreenEdgePanGestureRecognizer,
              is UIPinchGestureRecognizer:
-            if #available(iOS 11.0, *),
-                otherGestureRecognizer.name == "_UISheetInteractionBackgroundDismissRecognizer" {
-                // The pan gesture should recognize the dismiss gesture of a sheet modal simultaneously.
-                return true
-            }
             // all gestures of the tracking scroll view should be recognized in parallel
             // and handle them in self.handle(panGesture:)
             return scrollView?.gestureRecognizers?.contains(otherGestureRecognizer) ?? false

--- a/Framework/Sources/FloatingPanelCore.swift
+++ b/Framework/Sources/FloatingPanelCore.swift
@@ -199,6 +199,11 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
              is UIRotationGestureRecognizer,
              is UIScreenEdgePanGestureRecognizer,
              is UIPinchGestureRecognizer:
+            if #available(iOS 11.0, *),
+                otherGestureRecognizer.name == "_UISheetInteractionBackgroundDismissRecognizer" {
+                // The pan gesture should recognize the dismiss gesture of a sheet modal simultaneously.
+                return true
+            }
             // all gestures of the tracking scroll view should be recognized in parallel
             // and handle them in self.handle(panGesture:)
             return scrollView?.gestureRecognizers?.contains(otherGestureRecognizer) ?? false
@@ -220,6 +225,11 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
             if let view = otherGestureRecognizer.view, surfaceView.isDescendant(of: view) {
                 return true
             }
+        }
+        if #available(iOS 11.0, *),
+            otherGestureRecognizer.name == "_UISheetInteractionBackgroundDismissRecognizer" {
+            // The dismiss gesture of a sheet modal should not begin until the pan gesture fails.
+            return true
         }
         return false
     }
@@ -271,6 +281,11 @@ class FloatingPanelCore: NSObject, UIGestureRecognizerDelegate {
              is UIRotationGestureRecognizer,
              is UIScreenEdgePanGestureRecognizer,
              is UIPinchGestureRecognizer:
+            if #available(iOS 11.0, *),
+                otherGestureRecognizer.name == "_UISheetInteractionBackgroundDismissRecognizer" {
+                // Should begin the pan gesture without waiting the dismiss gesture of a sheet modal.
+                return false
+            }
             // Do not begin the pan gesture until these gestures fail
             return true
         default:


### PR DESCRIPTION
This PR fixes the following pane behavior in a sheet modal.

- Can't drag  a panel not including a scroll view in a sheet modal
- A view controller presented modally is removed after removing the inside panel by its removal interaction.

This fixes this issue https://github.com/SCENEE/FloatingPanel/issues/274#issuecomment-632681789 (Thanks to @FlashTang), and also fixes #298 partially.

**Limitation in Sheet modal**
If a panel's content view controller has a scroll view, a sheet modal always moves when a panel is dragged. This is because a sheet modal automatically capture a scroll view gestures and the lib is not able to prevent it.