### PR TITLE
Bugfix/fit to bounds constrains

### DIFF
--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -228,6 +228,7 @@ public class FloatingPanelSurfaceView: UIView {
         let rightConstraint = rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: containerMargins.right + contentInsets.right)
         let heightPadding = containerMargins.top + containerMargins.bottom + contentInsets.top + contentInsets.bottom
         let heightConstraint = contentView.heightAnchor.constraint(equalTo: heightAnchor, constant: -heightPadding)
+		heightConstraint.priority = UILayoutPriority(999)
         NSLayoutConstraint.activate([
             topConstraint,
             leftConstraint,

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -228,7 +228,7 @@ public class FloatingPanelSurfaceView: UIView {
         let rightConstraint = rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: containerMargins.right + contentInsets.right)
         let heightPadding = containerMargins.top + containerMargins.bottom + contentInsets.top + contentInsets.bottom
         let heightConstraint = contentView.heightAnchor.constraint(equalTo: heightAnchor, constant: -heightPadding)
-		heightConstraint.priority = UILayoutPriority(999)
+	heightConstraint.priority = UILayoutPriority(999)
         NSLayoutConstraint.activate([
             topConstraint,
             leftConstraint,

--- a/Framework/Sources/FloatingPanelSurfaceView.swift
+++ b/Framework/Sources/FloatingPanelSurfaceView.swift
@@ -228,7 +228,7 @@ public class FloatingPanelSurfaceView: UIView {
         let rightConstraint = rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: containerMargins.right + contentInsets.right)
         let heightPadding = containerMargins.top + containerMargins.bottom + contentInsets.top + contentInsets.bottom
         let heightConstraint = contentView.heightAnchor.constraint(equalTo: heightAnchor, constant: -heightPadding)
-	heightConstraint.priority = UILayoutPriority(999)
+        heightConstraint.priority = UILayoutPriority(999)
         NSLayoutConstraint.activate([
             topConstraint,
             leftConstraint,


### PR DESCRIPTION
Fix for this issue https://github.com/SCENEE/FloatingPanel/issues/294

Constraints break when we set fitToBounds contentMode and `surfaceView.contentInsets`. 

The main problem was in heightConstraint between `contentView` and `FloatingPanelSurfaceView` taking into account `surfaceView.contentInsets` and `offConstraints` from `FloatingPanelLayoutAdapter` which do not take into account `surfaceView.contentInsets`.

Constrains error example:
```
[LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600002010460 FloatingPanel.FloatingPanelSurfaceView:0x7feb4f46d170.bottom == FloatingPanel.FloatingPanelPassThroughView:0x7feb4f7736f0.bottom   (active)>",
    "<NSLayoutConstraint:0x6000020105a0 V:[FloatingPanel.FloatingPanelPassThroughView:0x7feb4f7736f0]-(0)-[FloatingPanel.FloatingPanelSurfaceView:0x7feb4f46d170]   (active)>",
    "<NSLayoutConstraint:0x600002010820 UIView:0x7feb4f472ec0.height == FloatingPanel.FloatingPanelSurfaceView:0x7feb4f46d170.height - 35   (active)>"
)
```