### PR TITLE
Fix an issue where keyboard opens above image picker

### DIFF
--- a/Framework/Sources/FloatingPanelTransitioning.swift
+++ b/Framework/Sources/FloatingPanelTransitioning.swift
@@ -47,8 +47,15 @@ class FloatingPanelPresentationController: UIPresentationController {
 
     override func containerViewWillLayoutSubviews() {
         guard
-            let fpc = presentedViewController as? FloatingPanelController
-            else { fatalError() }
+            let fpc = presentedViewController as? FloatingPanelController,
+            /**
+             This condition fixes https://github.com/SCENEE/FloatingPanel/issues/369.
+             The issue is that this method is called in presenting a
+             UIImagePickerViewController and then a FloatingPanelController
+             view is added unnecessarily.
+             */
+            fpc.presentedViewController == nil
+            else { return }
 
         /*
          * Layout the views managed by `FloatingPanelController` here for the


### PR DESCRIPTION
The cause of that is the containerViewWillLayoutSubviews() of FloatingPanelPresentationController is called in presenting a UIImagePickerViewController. As a result, a FloatingPanelController view is added unnecessarily.

By the way, the issue doesn't happen when a FloatingPanelController shows as a child view controller.

Fix #369 