### PR TITLE
Add escape gesture to close modal for VoiceOver users

### DIFF
--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -600,11 +600,11 @@ open class FloatingPanelController: UIViewController {
 
     // MARK: - Accessibility
 
-      open override func accessibilityPerformEscape() -> Bool {
+    open override func accessibilityPerformEscape() -> Bool {
         guard isRemovalInteractionEnabled else { return false }
         dismiss(animated: true, completion: nil)
         return true
-      }
+    }
 
     // MARK: - Utilities
 

--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -598,6 +598,14 @@ open class FloatingPanelController: UIViewController {
         }
     }
 
+    // MARK: - Accessibility
+
+      open override func accessibilityPerformEscape() -> Bool {
+        guard isRemovalInteractionEnabled else { return false }
+        dismiss(animated: true, completion: nil)
+        return true
+      }
+
     // MARK: - Utilities
 
     /// Updates the layout object from the delegate and lays out the views managed


### PR DESCRIPTION
Currently there is no simple way for Voice Over users to close Floating Panels that are modally presented. It is better to provide a cancel/close button that can selected by Voice Over but in the case that one isn't provided at least the escape gesture (two fingers dragged quickly back and forth in a rough "Z" shape) will work.