### PR TITLE
Reset the moveAnimator prop after a move animation

### DIFF
--- a/Examples/Samples/Sources/ViewController.swift
+++ b/Examples/Samples/Sources/ViewController.swift
@@ -142,6 +142,8 @@ class SampleListViewController: UIViewController {
             let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleSurface(tapGesture:)))
             tapGesture.cancelsTouchesInView = false
             tapGesture.numberOfTapsRequired = 2
+            // Prevents a delay to response a tap in menus of DebugTableViewController.
+            tapGesture.delaysTouchesEnded = false
             mainPanelVC.surfaceView.addGestureRecognizer(tapGesture)
         case .showNestedScrollView:
             mainPanelVC.panGestureRecognizer.delegateProxy = self
@@ -684,6 +686,8 @@ class DebugTableViewController: InspectableViewController {
         case animateScroll = "Animate Scroll"
         case changeContentSize = "Change content size"
         case reorder = "Reorder"
+        case moveToFull = "Move to Full"
+        case moveToHalf = "Move to Half"
     }
 
     var reorderButton: UIButton!
@@ -725,6 +729,10 @@ class DebugTableViewController: InspectableViewController {
             case .reorder:
                 button.addTarget(self, action: #selector(reorderItems), for: .touchUpInside)
                 reorderButton = button
+            case .moveToFull:
+                button.addTarget(self, action: #selector(moveToFull), for: .touchUpInside)
+            case .moveToHalf:
+                button.addTarget(self, action: #selector(moveToHalf), for: .touchUpInside)
             }
             buttonStackView.addArrangedSubview(button)
         }
@@ -783,6 +791,14 @@ class DebugTableViewController: InspectableViewController {
             items.append("Items \(i)")
         }
         tableView.reloadData()
+    }
+
+    @objc func moveToFull() {
+        (self.parent as! FloatingPanelController).move(to: .full, animated: true)
+    }
+
+    @objc func moveToHalf() {
+        (self.parent as! FloatingPanelController).move(to: .half, animated: true)
     }
 
     @objc func close(sender: UIButton) {

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -131,6 +131,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
                     ?? FloatingPanelDefaultBehavior().removePanelAnimator(vc, from: from, with: animationVector)
             default:
                 move(to: to, with: 0) {
+                    self.moveAnimator = nil
                     updateScrollView()
                     completion?()
                 }


### PR DESCRIPTION
If `moveAnimator` isn't null, `FloatingPanelPanGestureRecognizer.touchesBegan` detects `began` state quickly so that it doesn’t allow to work a tap gesture or tap action in a panel.

Resolve #392