### PR TITLE
Reset animator if move programmatically

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -833,6 +833,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
             completion: { [weak self] in
                 guard let self = self else { return }
                 self.layoutAdapter.activateLayout(for: targetPosition, forceLayout: true)
+                self.moveAnimator = nil
                 completion()
         })
         moveAnimator?.startAnimation()


### PR DESCRIPTION
`self.moveAnimator` needs to be reset after calling `move(to:)` programmatically, otherwise `FloatingPanelPanGestureRecognizer` will `began` when `moveAnimator != nil` (in the `touchesBegan()` method), then we can't tap any button on the `surfaceView` any more.