### PR TITLE
Add cornerCurve option to SurfaceAppearance

### DIFF
--- a/Examples/Maps/Maps/ViewController.swift
+++ b/Examples/Maps/Maps/ViewController.swift
@@ -91,6 +91,9 @@ class ViewController: UIViewController {
 extension FloatingPanelController {
     func setApearanceForPhone() {
         let appearance = SurfaceAppearance()
+        if #available(iOS 13.0, *) {
+            appearance.cornerCurve = .continuous
+        }
         appearance.cornerRadius = 8.0
         appearance.backgroundColor = .clear
         surfaceView.appearance = appearance

--- a/Sources/SurfaceView.swift
+++ b/Sources/SurfaceView.swift
@@ -50,6 +50,12 @@ public class SurfaceAppearance: NSObject {
     /// On iOS 10, they are not automatically masked because of a UIVisualEffectView issue. See https://forums.developer.apple.com/thread/50854
     public var cornerRadius: CGFloat = 0.0
 
+    /// Defines the curve used for rendering the rounded corners of the layer.
+    ///
+    /// Defaults to `.circular`.
+    @available(iOS 13.0, *)
+    public lazy var cornerCurve: CALayerCornerCurve = .circular
+
     /// An array of shadows used to create drop shadows underneath a surface view.
     public var shadows: [Shadow] = [Shadow()]
 
@@ -395,6 +401,10 @@ public class SurfaceView: UIView {
         } else {
             // Can't use `containerView.layer.mask` because of a UIVisualEffectView issue in iOS 10, https://forums.developer.apple.com/thread/50854
             // Instead, a user should display rounding corners appropriately.
+        }
+
+        if #available(iOS 13, *) {
+            containerView.layer.cornerCurve = appearance.cornerCurve
         }
     }
 

--- a/Sources/SurfaceView.swift
+++ b/Sources/SurfaceView.swift
@@ -317,8 +317,8 @@ public class SurfaceView: UIView {
 
         containerView.backgroundColor = appearance.backgroundColor
 
-        updateShadow()
         updateCornerRadius()
+        updateShadow()
         updateBorder()
 
         grabberHandle.layer.cornerRadius = grabberHandleSize.height / 2

--- a/Sources/SurfaceView.swift
+++ b/Sources/SurfaceView.swift
@@ -342,10 +342,9 @@ public class SurfaceView: UIView {
             shadowLayer.frame = layer.bounds
 
             let spread = shadow.spread
-            let shadowPath = UIBezierPath(roundedRect: containerView.frame.insetBy(dx: -spread,
-                                                                                   dy: -spread),
-                                          byRoundingCorners: [.allCorners],
-                                          cornerRadii: CGSize(width: appearance.cornerRadius, height: 0))
+            let shadowRect = containerView.frame.insetBy(dx: -spread, dy: -spread)
+            let shadowPath = UIBezierPath.path(roundedRect: shadowRect,
+                                               appearance: appearance)
             shadowLayer.shadowPath = shadowPath.cgPath
             shadowLayer.shadowColor = shadow.color.cgColor
             shadowLayer.shadowOffset = shadow.offset
@@ -354,16 +353,16 @@ public class SurfaceView: UIView {
             shadowLayer.shadowOpacity = shadow.opacity
 
             let mask = CAShapeLayer()
-            let path = UIBezierPath(roundedRect: containerView.frame,
-                                    byRoundingCorners: [.allCorners],
-                                    cornerRadii: CGSize(width: appearance.cornerRadius, height: 0))
+            let path = UIBezierPath.path(roundedRect: containerView.frame,
+                                         appearance: appearance)
             let size = window?.bounds.size ?? CGSize(width: 1000.0, height: 1000.0)
             path.append(UIBezierPath(rect: layer.bounds.insetBy(dx: -size.width,
                                                                 dy: -size.height)))
             mask.fillRule = .evenOdd
             mask.path = path.cgPath
             if #available(iOS 13.0, *) {
-                mask.cornerCurve = containerView.layer.cornerCurve
+                containerView.layer.cornerCurve = appearance.cornerCurve
+                mask.cornerCurve = appearance.cornerCurve
             }
             shadowLayer.mask = mask
         }
@@ -401,10 +400,6 @@ public class SurfaceView: UIView {
         } else {
             // Can't use `containerView.layer.mask` because of a UIVisualEffectView issue in iOS 10, https://forums.developer.apple.com/thread/50854
             // Instead, a user should display rounding corners appropriately.
-        }
-
-        if #available(iOS 13, *) {
-            containerView.layer.cornerCurve = appearance.cornerCurve
         }
     }
 

--- a/Sources/UIExtensions.swift
+++ b/Sources/UIExtensions.swift
@@ -205,7 +205,7 @@ extension UIEdgeInsets {
 extension UIBezierPath {
     static func path(roundedRect rect: CGRect, appearance: SurfaceAppearance) -> UIBezierPath {
         let cornerRadius = appearance.cornerRadius;
-        if #available(iOSApplicationExtension 13.0, *) {
+        if #available(iOS 13.0, *) {
             if appearance.cornerCurve == .circular {
                 let path = UIBezierPath()
                 let start = CGPoint(x: rect.minX + cornerRadius, y: rect.minY)

--- a/Sources/UIExtensions.swift
+++ b/Sources/UIExtensions.swift
@@ -201,3 +201,70 @@ extension UIEdgeInsets {
         return self.top + self.bottom
     }
 }
+
+extension UIBezierPath {
+    static func path(roundedRect rect: CGRect, appearance: SurfaceAppearance) -> UIBezierPath {
+        let cornerRadius = appearance.cornerRadius;
+        if #available(iOSApplicationExtension 13.0, *) {
+            if appearance.cornerCurve == .circular {
+                let path = UIBezierPath()
+                let start = CGPoint(x: rect.minX + cornerRadius, y: rect.minY)
+
+                path.move(to: start)
+
+                path.addLine(to: CGPoint(x: rect.maxX - cornerRadius, y: rect.minY))
+                if cornerRadius > 0 {
+                    path .addArc(withCenter: CGPoint(x: rect.maxX - cornerRadius,
+                                                     y: rect.minY + cornerRadius),
+                                 radius: cornerRadius,
+                                 startAngle: -0.5 * .pi,
+                                 endAngle: 0,
+                                 clockwise: true)
+                }
+
+                path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - cornerRadius))
+
+                if cornerRadius > 0 {
+                    path.addArc(withCenter: CGPoint(x: rect.maxX - cornerRadius,
+                                                    y: rect.maxY - cornerRadius),
+                                radius: cornerRadius,
+                                startAngle: 0,
+                                endAngle: .pi * 0.5,
+                                clockwise: true)
+                }
+
+                path.addLine(to: CGPoint(x: rect.minX + cornerRadius, y: rect.maxY))
+
+                if cornerRadius > 0 {
+                    path.addArc(withCenter: CGPoint(x: rect.minX + cornerRadius,
+                                                    y: rect.maxY - cornerRadius),
+                                radius: cornerRadius,
+                                startAngle: .pi * 0.5,
+                                endAngle: .pi,
+                                clockwise: true)
+                }
+
+                path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + cornerRadius))
+
+                if cornerRadius > 0 {
+                    path.addArc(withCenter: CGPoint(x: rect.minX + cornerRadius,
+                                                    y: rect.minY + cornerRadius),
+                                radius: cornerRadius,
+                                startAngle: .pi,
+                                endAngle: .pi * 1.5,
+                                clockwise: true)
+                }
+
+                path.addLine(to: start)
+
+                path.close()
+
+                return path
+            }
+        }
+        return UIBezierPath(roundedRect: rect,
+                            byRoundingCorners: [.allCorners],
+                            cornerRadii: CGSize(width: cornerRadius,
+                                                height: cornerRadius))
+    }
+}


### PR DESCRIPTION
This PR adds support to customize the `cornerCurve` of the `containerView` 

https://user-images.githubusercontent.com/5277837/102680653-c6e64880-41ec-11eb-8501-12ff86239b0d.mov

I might be wrong, but it seems like the mask is not following the `SurfaceAppearance`'s `cornerCurve`, initially this was because `updateShadow()` was called before `updateCornerRadius()`, but even after changing that the shadow seems to not adjust to the new `cornerCurve`. Any lead would be very welcome!

Also, I'm more than happy to close this PR if this can already be achieved in other ways, thank you :)

