### PR TITLE
Added optional `removalInteractionVelocityThreshold` value to `Behavior`

### DIFF
--- a/Sources/Behavior.swift
+++ b/Sources/Behavior.swift
@@ -43,6 +43,12 @@ public protocol FloatingPanelBehavior {
     /// This method allows a panel to activate the rubber band effect to a given edge of the surface view. By default, the effect is disabled.
     @objc optional
     func allowsRubberBanding(for edge: UIRectEdge) -> Bool
+    
+    /// Returns the velocity threshold for the default interactive removal gesture.
+    ///
+    /// In case `floatingPanel:shouldRemoveAt:with` is implemented, this value will not be used. The default value of `FloatingPanelDefaultBehavior` is 5.5
+    @objc optional
+    var removalInteractionVelocityThreshold: CGFloat { get }
 }
 
 /// The default behavior object for a panel
@@ -70,6 +76,8 @@ open class FloatingPanelDefaultBehavior: FloatingPanelBehavior {
     open func allowsRubberBanding(for edge: UIRectEdge) -> Bool {
         return false
     }
+    
+    open var removalInteractionVelocityThreshold: CGFloat = 5.5
 }
 
 class BehaviorAdapter {

--- a/Sources/Behavior.swift
+++ b/Sources/Behavior.swift
@@ -100,6 +100,10 @@ class BehaviorAdapter {
     var momentumProjectionRate: CGFloat {
         behavior.momentumProjectionRate ?? FloatingPanelDefaultBehavior().momentumProjectionRate
     }
+    
+    var removalInteractionVelocityThreshold: CGFloat {
+        behavior.removalInteractionVelocityThreshold ?? FloatingPanelDefaultBehavior().removalInteractionVelocityThreshold
+    }
 
     func redirectionalProgress(from: FloatingPanelState, to: FloatingPanelState) -> CGFloat {
         behavior.redirectionalProgress?(vc, from: from, to: to) ?? FloatingPanelDefaultBehavior().redirectionalProgress(vc,from: from, to: to)

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -713,7 +713,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         if let result = vc.delegate?.floatingPanel?(vc, shouldRemoveAt: vc.surfaceLocation, with: velocityVector) {
             return result
         }
-        let threshold = vc.behavior.removalInteractionVelocityThreshold ?? CGFloat(5.5)
+        let threshold = behaviorAdapter.removalInteractionVelocityThreshold
         switch layoutAdapter.position {
         case .top:
             return (velocityVector.dy <= -threshold)

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -713,7 +713,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         if let result = vc.delegate?.floatingPanel?(vc, shouldRemoveAt: vc.surfaceLocation, with: velocityVector) {
             return result
         }
-        let threshold = CGFloat(5.5)
+        let threshold = vc.behavior.removalInteractionVelocityThreshold ?? CGFloat(5.5)
         switch layoutAdapter.position {
         case .top:
             return (velocityVector.dy <= -threshold)


### PR DESCRIPTION
Currently, in order to change the velocity threshold for the interactive removal gesture, we need to duplicate the default code of `floatingPanel:shouldRemoveAt:with` like this:

```swift
func defaultFloatingPanel(_ fpc: FloatingPanelController, shouldRemoveAt location: CGPoint, with velocity: CGVector) -> Bool {
        let threshold = CGFloat(1.5) // Changed from 5.5 -> 1.5

        switch fpc.layout.position {
        case .top:
            return (velocity.dy <= -threshold)
        case .left:
            return (velocity.dx <= -threshold)
        case .bottom:
            return (velocity.dy >= threshold)
        case .right:
            return (velocity.dx >= threshold)
        }
 }
```

I added an optional variable `removalInteractionVelocityThreshold` to `Behavior`, which let’s the user configure the velocity threshold for the default `floatingPanel:shouldRemoveAt:with` implementation.

Now the only thing needed to change the threshold is this:

```swift
let behavior = FloatingPanelDefaultBehavior()
behavior.removalInteractionVelocityThreshold = 1.5
fpc.behavior = behavior
```