### PR TITLE
Fix an issue where not dragging a panel by priority of Layout.interactionConstraint

### DIFF
--- a/Sources/Layout.swift
+++ b/Sources/Layout.swift
@@ -503,7 +503,7 @@ class LayoutAdapter {
             constraint = surfaceView.leftAnchor.constraint(equalTo: vc.view.leftAnchor, constant: initialConst)
         }
 
-        constraint.priority = .defaultHigh
+        constraint.priority = .required
         constraint.identifier = "FloatingPanel-interaction"
 
         NSLayoutConstraint.activate([constraint])


### PR DESCRIPTION
I applied `.defaultHigh` priority which might be safe to prevent an ambiguous layout error. But that causes this issue, so I have to use `.required` priority.

See more detail [#424 issue](https://github.com/SCENEE/FloatingPanel/issues/424).