### PR TITLE
Prepare v2.2.0

### DIFF
--- a/FloatingPanel.podspec
+++ b/FloatingPanel.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                = "FloatingPanel"
-  s.version             = "2.1.0"
+  s.version             = "2.2.0"
   s.summary             = "FloatingPanel is a clean and easy-to-use UI component of a floating panel interface."
   s.description         = <<-DESC
 FloatingPanel is a clean and easy-to-use UI component for a new interface introduced in Apple Maps, Shortcuts and Stocks app.

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sources/Logger.swift
+++ b/Sources/Logger.swift
@@ -68,7 +68,7 @@ struct Logger {
 
         hook?(log, level)
 
-        os_log("%@", log: osLog, type: level.osLogType, log)
+        os_log("%{public}@", log: osLog, type: level.osLogType, log)
     }
 
     private func getPrettyFunction(_ function: String, _ file: String) -> String {

--- a/Sources/Logger.swift
+++ b/Sources/Logger.swift
@@ -3,6 +3,7 @@
 import Foundation
 import os.log
 
+// Must be a variable to use `hook` property in testing
 var log = {
     return Logger()
 }()


### PR DESCRIPTION
Bumped up the minor version and added some minor improvements

- [x] Migrate travis-ci.org to  travis-ci.com -> Move to GitHub actions
- [x] Release note
- [x] Update CocoaPods repo 