### PR TITLE
Fixed the crash when ownerVC is nil.

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -847,7 +847,8 @@ class Core: NSObject, UIGestureRecognizerDelegate {
                 ownerVC.notifyDidMove()
         },
             completion: { [weak self] in
-                guard let self = self else { return }
+                guard let self = self,
+                      self.ownerVC != nil else { return }
                 self.layoutAdapter.activateLayout(for: targetPosition, forceLayout: true)
                 completion()
         })


### PR DESCRIPTION
I met the crash during the animation of the floating panel. I think https://github.com/SCENEE/FloatingPanel/commit/e783b9290529902157a13c2df66fbf42ef122c1d fixed a lot for it. But somehow I still saw crash happened during the animation. After investigation, I think `ownerVC` should be checked in the completion as well.