### PR TITLE
Fix backdrop flickering

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -187,7 +187,12 @@ class Core: NSObject, UIGestureRecognizerDelegate {
     // MARK: - Layout update
 
     private func updateLayout(to target: FloatingPanelState) {
-        self.layoutAdapter.activateLayout(for: state, forceLayout: true)
+        self.layoutAdapter.activateLayout(for: target, forceLayout: true)
+        self.backdropView.alpha = self.getBackdropAlpha(for: target)
+    }
+
+    private func getBackdropAlpha(for target: FloatingPanelState) -> CGFloat {
+        return target == .hidden ? 0.0 : layoutAdapter.backdropAlpha(for: target)
     }
 
     func getBackdropAlpha(at cur: CGFloat, with translation: CGFloat) -> CGFloat {
@@ -210,9 +215,8 @@ class Core: NSObject, UIGestureRecognizerDelegate {
 
         if pre == next {
             return preAlpha
-        } else {
-            return preAlpha + max(min(1.0, 1.0 - (next - cur) / (next - pre) ), 0.0) * (nextAlpha - preAlpha)
         }
+        return preAlpha + max(min(1.0, 1.0 - (next - cur) / (next - pre) ), 0.0) * (nextAlpha - preAlpha)
     }
 
     // MARK: - UIGestureRecognizerDelegate
@@ -854,7 +858,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
             completion: { [weak self] in
                 guard let self = self,
                       self.ownerVC != nil else { return }
-                self.layoutAdapter.activateLayout(for: targetPosition, forceLayout: true)
+                self.updateLayout(to: targetPosition)
                 completion()
         })
         moveAnimator?.startAnimation()

--- a/Sources/Layout.swift
+++ b/Sources/Layout.swift
@@ -744,8 +744,6 @@ class LayoutAdapter {
 
         var state = state
 
-        setBackdropAlpha(of: state)
-
         if validStates.contains(state) == false {
             state = layout.initialState
         }
@@ -773,14 +771,6 @@ class LayoutAdapter {
         guard surfaceView.window != nil else { return }
         #endif
         surfaceView.superview?.layoutIfNeeded()
-    }
-
-    private func setBackdropAlpha(of target: FloatingPanelState) {
-        if target == .hidden {
-            self.backdropView.alpha = 0.0
-        } else {
-            self.backdropView.alpha = backdropAlpha(for: target)
-        }
     }
 
     func backdropAlpha(for state: FloatingPanelState) -> CGFloat {


### PR DESCRIPTION
This issue occurs when a panel is swung down with all one's might.
The trigger is here.
```swift
    func floatingPanelWillEndDragging(_ vc: FloatingPanelController, withVelocity velocity: CGPoint, targetState: UnsafeMutablePointer<FloatingPanelState>) {
        if targetState.pointee != .full {
            owner.searchVC.hideHeader(animated: true)
        }
        if targetState.pointee == .tip {
>>>         vc.contentMode = .static
        }
    }
```
However, any library user expect to affect the backdrop by this code.
And then I recondiered the reason why the backdrop alpha changes in
activateLayout(for:forceLayout:) and it's because the animation using
CAAnimation.

Therefore I decided to move the point to change the backdrop alpha into
the move animation's completion handler.

And also the responsibility of `setBackdropAlpha(of:)` was moved into
`Core` because `Core` takes on a role of changing the backdrop alpha.