### PR TITLE
Make the pan gesture keep disabled

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -837,6 +837,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
     }
 
     private func tearDownActiveInteraction() {
+        guard panGestureRecognizer.isEnabled else { return }
         // Cancel the pan gesture so that panningEnd(with:velocity:) is called
         panGestureRecognizer.isEnabled = false
         panGestureRecognizer.isEnabled = true

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -766,6 +766,13 @@ class CoreTests: XCTestCase {
             (#line, tipPos, CGPoint(x: 0.0, y: 1000.0), .hidden),
             ])
     }
+
+    func test_keep_pan_gesture_disabled() {
+        let fpc = FloatingPanelController()
+        fpc.panGestureRecognizer.isEnabled = false
+        fpc.showForTest()
+        XCTAssertFalse(fpc.panGestureRecognizer.isEnabled)
+    }
 }
 
 private class FloatingPanelLayout3Positions: FloatingPanelTestLayout {


### PR DESCRIPTION
Because a panel's pan gesture becomes enabled in showing it even after it is disabled.

Related https://github.com/scenee/FloatingPanel/discussions/485