### PR TITLE
Use scrollView.contentOffset when stopping ongoing scroll deceleration

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -710,8 +710,9 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         if stopScrollDeceleration {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
-
-                self.stopScrolling(at: self.initialScrollOffset)
+                guard let scrollView = self.scrollView else { return }
+                
+                self.stopScrolling(at: scrollView.contentOffset)
             }
         }
 


### PR DESCRIPTION
Applies fixes as described in #526 