### PR TITLE
fix: add missing import UIKit

### DIFF
--- a/Examples/Maps-SwiftUI/Maps/SearchPanelPhoneDelegate.swift
+++ b/Examples/Maps-SwiftUI/Maps/SearchPanelPhoneDelegate.swift
@@ -1,6 +1,7 @@
 // Copyright 2021 the FloatingPanel authors. All rights reserved. MIT license.
 
 import FloatingPanel
+import UIKit
 
 final class SearchPanelPhoneDelegate: FloatingPanelControllerDelegate {
     func floatingPanelWillBeginDragging(_ vc: FloatingPanelController) {


### PR DESCRIPTION
Examples/Maps-SwiftUI/Maps/SearchPanelPhoneDelegate.swift add missing import UIKit