### PR TITLE
Fix floating panel content view constraints (#546)

### DIFF
--- a/Examples/Maps-SwiftUI/Maps/FloatingPanel/FloatingPanelView.swift
+++ b/Examples/Maps-SwiftUI/Maps/FloatingPanel/FloatingPanelView.swift
@@ -98,6 +98,10 @@ struct FloatingPanelView<Content: View, FloatingPanelContent: View>: UIViewContr
             hostingViewController.view.backgroundColor = nil
             fpc.set(contentViewController: hostingViewController)
             fpc.addPanel(toParent: parentViewController, at: 1, animated: false)
+            
+            // Invalidate the UIHostingController's intrinsic content size
+            // as it did not yet know the floating panel constraints.
+            hostingViewController.view.invalidateIntrinsicContentSize()
         }
 
         func updateIfNeeded() {


### PR DESCRIPTION
See https://stackoverflow.com/questions/58399123/uihostingcontroller-should-expand-to-fit-contents

The UIHostingController, when inspected, has space along the bottom.
![view-heirarchy](https://user-images.githubusercontent.com/933511/172795721-a070259e-31d6-4358-b6fb-4750d99d5211.png)

Invalidating the intrinsic content size seems to fix this issue as well as the animation stuttering (#546).

Also, this only seems to occur when `FloatingPanelController.contentMode` is set to `.fitToBounds`.

The jumpy animation when dragging below the bottom animation (to then animate back up a small distance) still exists.

Apologies if this is incorrect as I've only started playing around with Swift / SwiftUI / UIKit <1 week ago. Can a more seasoned expert explain why this needs to be done after `show` is called? (Otherwise the stuttering persists.)

It seems to me that maybe this should be the responsibility of `FloatingPanelController.addPanel()`? But this was SwiftUI-specific so I only added it to the SwiftUI example.