### PR TITLE
Fix `cornerCurve` property availability compilation fail

### DIFF
--- a/Sources/SurfaceView.swift
+++ b/Sources/SurfaceView.swift
@@ -54,7 +54,12 @@ public class SurfaceAppearance: NSObject {
     ///
     /// Defaults to `.circular`.
     @available(iOS 13.0, *)
-    public lazy var cornerCurve: CALayerCornerCurve = .circular
+    public var cornerCurve: CALayerCornerCurve {
+        get { _cornerCurve ?? .circular }
+        set { _cornerCurve = newValue }
+    }
+
+    private var _cornerCurve: CALayerCornerCurve?
 
     /// An array of shadows used to create drop shadows underneath a surface view.
     public var shadows: [Shadow] = [Shadow()]


### PR DESCRIPTION
With Xcode 14 Beta 1 library fails to compile with following error

```
Stored properties cannot be marked potentially unavailable with `@available`
```

<img width="772" alt="Screenshot of compilation error on cornerCurve line" src="https://user-images.githubusercontent.com/1136316/173188034-b7781db9-274e-45b4-8866-524c005c041d.png">

Because `CALayerCornerCurve` is not marked with any `@available` annotation it is possible to declare private optional storage of it.
With this change everything compiles.