### PR TITLE
Replace PR #551 change using fatalError()

### DIFF
--- a/Sources/Transitioning.swift
+++ b/Sources/Transitioning.swift
@@ -99,15 +99,15 @@ class ModalPresentTransition: NSObject, UIViewControllerAnimatedTransitioning {
             return animator
         }
 
-        // Ensure the current(initial) state is hidden. Because `fpc.transitionAnimator` can be nil if not.
-        fpc.move(to: .hidden, animated: false)
-
         fpc.suspendTransitionAnimator(true)
         fpc.show(animated: true) { [weak fpc] in
             fpc?.suspendTransitionAnimator(false)
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }
-        return fpc.transitionAnimator!
+        guard let transitionAnimator = fpc.transitionAnimator else {
+            fatalError("The panel state must be `hidden` but it is `\(fpc.state)`")
+        }
+        return transitionAnimator
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {


### PR DESCRIPTION
This resolves #561. The solution of #551 has a side effect on the case of #561, so I replace the solution with fatalError.

Instead of continuing to work a modal presentation transition even if it's not `.hidden` state, it just crash using the fatalError and the error message as a programmer error.