### PR TITLE
Fix the backdrop alpha issue (#572)

### DIFF
--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -316,7 +316,7 @@ open class FloatingPanelController: UIViewController {
         // Change a layout for the new view size
         if let newLayout = self.delegate?.floatingPanel?(self, layoutFor: size) {
             layout = newLayout
-            activateLayout(forceLayout: false)
+            activateLayout(forceLayout: true)
         }
 
         if view.translatesAutoresizingMaskIntoConstraints {
@@ -335,7 +335,7 @@ open class FloatingPanelController: UIViewController {
         // Change a layout for the new trait collection
         if let newLayout = self.delegate?.floatingPanel?(self, layoutFor: newCollection) {
             self.layout = newLayout
-            activateLayout(forceLayout: false)
+            activateLayout(forceLayout: true)
         }
     }
 

--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -401,8 +401,10 @@ open class FloatingPanelController: UIViewController {
     }
 
     private func activateLayout(forceLayout: Bool = false) {
-        floatingPanel.activateLayout(forceLayout: forceLayout,
-                                     contentInsetAdjustmentBehavior: contentInsetAdjustmentBehavior)
+        floatingPanel.activateLayout(
+            forceLayout: forceLayout,
+            contentInsetAdjustmentBehavior: contentInsetAdjustmentBehavior
+        )
     }
 
     func remove() {

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -197,8 +197,10 @@ class Core: NSObject, UIGestureRecognizerDelegate {
 
     // MARK: - Layout update
 
-    func activateLayout(forceLayout: Bool = false,
-                        contentInsetAdjustmentBehavior: FloatingPanelController.ContentInsetAdjustmentBehavior) {
+    func activateLayout(
+        forceLayout: Bool = false,
+        contentInsetAdjustmentBehavior: FloatingPanelController.ContentInsetAdjustmentBehavior
+    ) {
         layoutAdapter.prepareLayout()
 
         // preserve the current content offset if contentInsetAdjustmentBehavior is `.always`

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -210,7 +210,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         }
 
         layoutAdapter.updateStaticConstraint()
-        layoutAdapter.activateLayout(for: state, forceLayout: true)
+        layoutAdapter.activateLayout(for: state, forceLayout: forceLayout)
 
         // Update the backdrop alpha only when called in `Controller.show(animated:completion:)`
         // Because that prevents a backdrop flicking just before presenting a panel(#466).

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -205,6 +205,9 @@ class CoreTests: XCTestCase {
             func floatingPanel(_ fpc: FloatingPanelController, layoutFor newCollection: UITraitCollection) -> FloatingPanelLayout { layout }
             func floatingPanel(_ fpc: FloatingPanelController, layoutFor size: CGSize) -> FloatingPanelLayout { layout }
         }
+        func _floor(_ alpha: CGFloat) -> CGFloat {
+            return floor(fpc.backdropView.alpha * 1e+06) / 1e+06
+        }
 
         let delegate = TestDelegate()
         let fpc = FloatingPanelController(delegate: delegate)
@@ -213,20 +216,20 @@ class CoreTests: XCTestCase {
         fpc.showForTest()
 
         fpc.move(to: .full, animated: false)
-        XCTAssertEqual(floor(fpc.backdropView.alpha * 1000_000) / 1000_000, 0.3)
+        XCTAssertEqual(_floor(fpc.backdropView.alpha), 0.3)
 
         fpc.move(to: .half, animated: false)
         XCTAssertEqual(fpc.backdropView.alpha, 0.0)
 
         fpc.move(to: .tip, animated: false)
-        XCTAssertEqual(floor(fpc.backdropView.alpha * 1000_000) / 1000_000, 0.3)
+        XCTAssertEqual(_floor(fpc.backdropView.alpha), 0.3)
 
         let exp1 = expectation(description: "move to full with animation")
         fpc.move(to: .full, animated: true) {
             exp1.fulfill()
         }
         wait(for: [exp1], timeout: 1.0)
-        XCTAssertEqual(floor(fpc.backdropView.alpha * 1000_000) / 1000_000, 0.3)
+        XCTAssertEqual(_floor(fpc.backdropView.alpha), 0.3)
 
         let exp2 = expectation(description: "move to half with animation")
         fpc.move(to: .half, animated: true) {
@@ -244,12 +247,12 @@ class CoreTests: XCTestCase {
         fpc.contentMode = .fitToBounds
         XCTAssertEqual(fpc.backdropView.alpha, 0.0)  // Must not affect the backdrop alpha by changing the content mode
         wait(for: [exp3], timeout: 1.0)
-        XCTAssertEqual(floor(fpc.backdropView.alpha * 1000_000) / 1000_000, 0.3)
+        XCTAssertEqual(_floor(fpc.backdropView.alpha), 0.3)
 
         // Test a size class change of FloatingPanelController.view
 
         fpc.move(to: .full, animated: false)
-        XCTAssertEqual(floor(fpc.backdropView.alpha * 1000_000) / 1000_000, 0.3)
+        XCTAssertEqual(_floor(fpc.backdropView.alpha), 0.3)
         fpc.willTransition(to: UITraitCollection(horizontalSizeClass: .regular), with: MockTransitionCoordinator())
         XCTAssertEqual(fpc.backdropView.alpha, 0.0) // Must update the alpha by BackdropTestLayout2 in TestDelegate.
 
@@ -258,7 +261,7 @@ class CoreTests: XCTestCase {
         fpc.move(to: .full, animated: false)
         delegate.layout = BackdropTestLayout()
         fpc.invalidateLayout()
-        XCTAssertEqual(floor(fpc.backdropView.alpha * 1000_000) / 1000_000, 0.3)
+        XCTAssertEqual(_floor(fpc.backdropView.alpha), 0.3)
 
         delegate.layout = BackdropTestLayout2()
         fpc.viewWillTransition(to: CGSize.zero, with: MockTransitionCoordinator())

--- a/Tests/TestSupports.swift
+++ b/Tests/TestSupports.swift
@@ -77,3 +77,25 @@ class FloatingPanelProjectableBehavior: FloatingPanelBehavior {
         return true
     }
 }
+
+class MockTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
+    func animate(alongsideTransition animation: ((UIViewControllerTransitionCoordinatorContext) -> Void)?, completion: ((UIViewControllerTransitionCoordinatorContext) -> Void)? = nil) -> Bool { true }
+    func animateAlongsideTransition(in view: UIView?, animation: ((UIViewControllerTransitionCoordinatorContext) -> Void)?, completion: ((UIViewControllerTransitionCoordinatorContext) -> Void)? = nil) -> Bool { true }
+    func notifyWhenInteractionEnds(_ handler: @escaping (UIViewControllerTransitionCoordinatorContext) -> Void) {}
+    func notifyWhenInteractionChanges(_ handler: @escaping (UIViewControllerTransitionCoordinatorContext) -> Void) {}
+    var isAnimated: Bool = false
+    var presentationStyle: UIModalPresentationStyle = .fullScreen
+    var initiallyInteractive: Bool = false
+    var isInterruptible: Bool = false
+    var isInteractive: Bool = false
+    var isCancelled: Bool = false
+    var transitionDuration: TimeInterval = 0.25
+    var percentComplete: CGFloat = 0
+    var completionVelocity: CGFloat = 0
+    var completionCurve: UIView.AnimationCurve = .easeInOut
+    func viewController(forKey key: UITransitionContextViewControllerKey) -> UIViewController? { nil }
+    func view(forKey key: UITransitionContextViewKey) -> UIView? { nil }
+    var containerView: UIView { UIView() }
+    var targetTransform: CGAffineTransform = .identity
+}
+


### PR DESCRIPTION
This fixes https://github.com/scenee/FloatingPanel/issues/572. The main change is that `true` is passed as a `forceLayout` parameter into `viewWillTransition(to:with:)` callbacks.

Because it's necessary for the backdrop alpha's update when the view size or its size classes changes.

This also fixes a regression by https://github.com/scenee/FloatingPanel/commit/9c45c311901b90be90653aff63871ea751fae171.

```diff
-        layoutAdapter.activateLayout(for: state, forceLayout: true)
+        layoutAdapter.activateLayout(for: state, forceLayout: forceLayout)
```

The behavior before the above second change indicates that the method is working well even when `forceLayout` is set to `true` in their callbacks.