### PR TITLE
Fix #524 

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -20,13 +20,11 @@ class Core: NSObject, UIGestureRecognizerDelegate {
             if let cur = scrollView {
                 if oldValue == nil {
                     initialScrollOffset = cur.contentOffset
-                    scrollBounce = cur.bounces
                     scrollIndictorVisible = cur.showsVerticalScrollIndicator
                 }
             } else {
                 if let pre = oldValue {
                     pre.isDirectionalLockEnabled = false
-                    pre.bounces = scrollBounce
                     pre.showsVerticalScrollIndicator = scrollIndictorVisible
                 }
             }
@@ -64,7 +62,6 @@ class Core: NSObject, UIGestureRecognizerDelegate {
     // Scroll handling
     private var initialScrollOffset: CGPoint = .zero
     private var stopScrollDeceleration: Bool = false
-    private var scrollBounce = false
     private var scrollIndictorVisible = false
 
     // MARK: - Interface
@@ -1033,11 +1030,11 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         }
         log.debug("lock scroll view")
 
-        scrollBounce = scrollView.bounces
         scrollIndictorVisible = scrollView.showsVerticalScrollIndicator
 
+        // Must not modify the UIScrollView.bounces property here. If you reset it to unlock the tracking scroll view,
+        // UIScrollView may unexpectedly alter the scroll offset when dealing with small scrollable content.
         scrollView.isDirectionalLockEnabled = true
-        scrollView.bounces = false
         scrollView.showsVerticalScrollIndicator = false
     }
 
@@ -1046,7 +1043,6 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         log.debug("unlock scroll view")
 
         scrollView.isDirectionalLockEnabled = false
-        scrollView.bounces = scrollBounce
         scrollView.showsVerticalScrollIndicator = scrollIndictorVisible
     }
 

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -157,7 +157,7 @@ extension UIGestureRecognizer.State: CustomDebugStringConvertible {
 
 extension UIScrollView {
     var isLocked: Bool {
-        return !showsVerticalScrollIndicator && !bounces &&  isDirectionalLockEnabled
+        return !showsVerticalScrollIndicator && isDirectionalLockEnabled
     }
     var fp_contentInset: UIEdgeInsets {
         if #available(iOS 11.0, *) {

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -12,27 +12,22 @@ class CoreTests: XCTestCase {
 
         let contentVC1 = UITableViewController(nibName: nil, bundle: nil)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, true)
-        XCTAssertEqual(contentVC1.tableView.bounces, true)
         fpc.set(contentViewController: contentVC1)
         fpc.track(scrollView: contentVC1.tableView)
         fpc.showForTest()
 
         XCTAssertEqual(fpc.state, .half)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, false)
-        XCTAssertEqual(contentVC1.tableView.bounces, false)
 
         fpc.move(to: .full, animated: false)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, true)
-        XCTAssertEqual(contentVC1.tableView.bounces, true)
 
         fpc.move(to: .tip, animated: false)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, false)
-        XCTAssertEqual(contentVC1.tableView.bounces, false)
 
         let exp1 = expectation(description: "move to full with animation")
         fpc.move(to: .full, animated: true) {
             XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, true)
-            XCTAssertEqual(contentVC1.tableView.bounces, true)
             exp1.fulfill()
         }
         wait(for: [exp1], timeout: 1.0)
@@ -40,7 +35,6 @@ class CoreTests: XCTestCase {
         let exp2 = expectation(description: "move to tip with animation")
         fpc.move(to: .tip, animated: false) {
             XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, false)
-            XCTAssertEqual(contentVC1.tableView.bounces, false)
             exp2.fulfill()
         }
         wait(for: [exp2], timeout: 1.0)
@@ -48,13 +42,11 @@ class CoreTests: XCTestCase {
         // Reset the content vc
         let contentVC2 = UITableViewController(nibName: nil, bundle: nil)
         XCTAssertEqual(contentVC2.tableView.showsVerticalScrollIndicator, true)
-        XCTAssertEqual(contentVC2.tableView.bounces, true)
         fpc.set(contentViewController: contentVC2)
         fpc.track(scrollView: contentVC2.tableView)
         fpc.show(animated: false, completion: nil)
         XCTAssertEqual(fpc.state, .half)
         XCTAssertEqual(contentVC2.tableView.showsVerticalScrollIndicator, false)
-        XCTAssertEqual(contentVC2.tableView.bounces, false)
     }
 
     func test_getBackdropAlpha_1positions() {


### PR DESCRIPTION
This PR stops changing and reseting UIScrollView.bounces when locking and unlocking a scroll view.

#524 
