### PR TITLE
Fixes an issue where dismissalTapGestureRecognizer doesn't work in one case

### DIFF
--- a/Examples/Samples/Sources/UseCases/UseCase.swift
+++ b/Examples/Samples/Sources/UseCases/UseCase.swift
@@ -10,6 +10,7 @@ enum UseCase: Int, CaseIterable {
     case showPanelModal
     case showMultiPanelModal
     case showPanelInSheetModal
+    case showOnWindow
     case showTabBar
     case showPageView
     case showPageContentView
@@ -34,6 +35,7 @@ extension UseCase {
         case .showModal: return "Show Modal"
         case .showPanelModal: return "Show Panel Modal"
         case .showMultiPanelModal: return "Show Multi Panel Modal"
+        case .showOnWindow: return "Show Panel over Window"
         case .showPanelInSheetModal: return "Show Panel in Sheet Modal"
         case .showTabBar: return "Show Tab Bar"
         case .showPageView: return "Show Page View"
@@ -65,6 +67,7 @@ extension UseCase {
         case .showDetail: return .storyboard(String(describing: DetailViewController.self))
         case .showModal: return .storyboard(String(describing: ModalViewController.self))
         case .showMultiPanelModal: return .viewController(DebugTableViewController())
+        case .showOnWindow: return .viewController(DebugTableViewController())
         case .showPanelInSheetModal: return .viewController(DebugTableViewController())
         case .showPanelModal: return .viewController(DebugTableViewController())
         case .showTabBar: return .storyboard(String(describing: TabBarViewController.self))

--- a/Examples/Samples/Sources/UseCases/UseCaseController.swift
+++ b/Examples/Samples/Sources/UseCases/UseCaseController.swift
@@ -11,6 +11,7 @@ final class UseCaseController: NSObject {
     private var detailPanelVC: FloatingPanelController!
     private var settingsPanelVC: FloatingPanelController!
     private lazy var pagePanelController = PagePanelController()
+    private lazy var overWindowPanelVC = FloatingPanelController()
 
     init(mainVC: MainViewController) {
         self.mainVC = mainVC
@@ -157,6 +158,19 @@ extension UseCaseController {
             let fpc = MultiPanelController()
             mainVC.present(fpc, animated: true, completion: nil)
 
+        case .showOnWindow:
+            let fpc = overWindowPanelVC
+            fpc.backdropView.dismissalTapGestureRecognizer.isEnabled = true
+            fpc.set(contentViewController: contentVC)
+            fpc.ext_trackScrollView(in: contentVC)
+
+            guard let window = UIApplication.shared.windows.first else { fatalError("Any window not found") }
+
+            window.addSubview(fpc.view)
+            fpc.view.frame = window.bounds
+            fpc.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+            fpc.show(animated: true)
         case .showPanelInSheetModal:
             let fpc = FloatingPanelController()
             let contentVC = UIViewController()

--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -414,8 +414,14 @@ open class FloatingPanelController: UIViewController {
                 guard let self = self else { return }
                 self.delegate?.floatingPanelDidRemove?(self)
             }
-        } else {
+        } else if parent != nil {
             removePanelFromParent(animated: true)
+        } else {
+            hide(animated: true) { [weak self] in
+                guard let self = self else { return }
+                self.view.removeFromSuperview()
+                self.delegate?.floatingPanelDidRemove?(self)
+            }
         }
     }
 


### PR DESCRIPTION
`dismissalTapGestureRecognizer `didn't work when the panel is added into UIWindow directly as its subview. This PR fixes this issue and also adds the use case in Samples.app.

Resolve #590