### PR TITLE
Suggestion: Fix scrollview content staying non-interactive after slowly swiping down

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -1050,7 +1050,11 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         // Must use setContentOffset(_:animated) to force-stop deceleration
         guard let scrollView = scrollView else { return }
         var offset = scrollView.contentOffset
-        setValue(contentOffset, to: &offset)
+        if contentOffset.y >= 0 {
+            setValue(contentOffset, to: &offset)
+        } else {
+            offset = CGPoint(x: 0, y: 0)
+        }
         scrollView.setContentOffset(offset, animated: false)
     }
 


### PR DESCRIPTION
This change is what fixed a certain bug for our app: Whenever we had the FloatingPanel at full height and dragged it down, the content (which was a scroll view) locked at a negativ offset. It was most obvious when the whitespace was large, hence the offset was something around `-100.0`. At the same time, the contents (like buttons) were non-interactive.

Now, this behavior only surfaced recently when we needed to update our SwiftUI wrapper code. Previously, we used the code from the Map-SwiftUI example. However, once we added a TextField, the content's were not updated based on the text variable.
The solution was to update the content's `UIHostingController`'s `rootView`. Happy to hear if there are more efficient changes that can be done to the example code.

Please take a look at the changes of this PR and evaluate if this is actually what is supposed to happen and doesn't brake in other cases. We couldn't find any so far.