### PR TITLE
[Revised] Fix an issue scrolling jumps with a small scroll view content (#524)

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -20,11 +20,13 @@ class Core: NSObject, UIGestureRecognizerDelegate {
             if let cur = scrollView {
                 if oldValue == nil {
                     initialScrollOffset = cur.contentOffset
+                    scrollBounce = cur.bounces
                     scrollIndictorVisible = cur.showsVerticalScrollIndicator
                 }
             } else {
                 if let pre = oldValue {
                     pre.isDirectionalLockEnabled = false
+                    pre.bounces = scrollBounce
                     pre.showsVerticalScrollIndicator = scrollIndictorVisible
                 }
             }
@@ -62,6 +64,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
     // Scroll handling
     private var initialScrollOffset: CGPoint = .zero
     private var stopScrollDeceleration: Bool = false
+    private var scrollBounce = false
     private var scrollIndictorVisible = false
 
     // MARK: - Interface
@@ -1030,11 +1033,11 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         }
         log.debug("lock scroll view")
 
+        scrollBounce = scrollView.bounces
         scrollIndictorVisible = scrollView.showsVerticalScrollIndicator
 
-        // Must not modify the UIScrollView.bounces property here. If you reset it to unlock the tracking scroll view,
-        // UIScrollView may unexpectedly alter the scroll offset when dealing with small scrollable content.
         scrollView.isDirectionalLockEnabled = true
+        scrollView.bounces = false
         scrollView.showsVerticalScrollIndicator = false
     }
 
@@ -1043,6 +1046,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         log.debug("unlock scroll view")
 
         scrollView.isDirectionalLockEnabled = false
+        scrollView.bounces = scrollBounce
         scrollView.showsVerticalScrollIndicator = scrollIndictorVisible
     }
 

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -157,7 +157,7 @@ extension UIGestureRecognizer.State: CustomDebugStringConvertible {
 
 extension UIScrollView {
     var isLocked: Bool {
-        return !showsVerticalScrollIndicator && isDirectionalLockEnabled
+        return !showsVerticalScrollIndicator && !bounces &&  isDirectionalLockEnabled
     }
     var fp_contentInset: UIEdgeInsets {
         if #available(iOS 11.0, *) {

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -12,22 +12,27 @@ class CoreTests: XCTestCase {
 
         let contentVC1 = UITableViewController(nibName: nil, bundle: nil)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, true)
+        XCTAssertEqual(contentVC1.tableView.bounces, true)
         fpc.set(contentViewController: contentVC1)
         fpc.track(scrollView: contentVC1.tableView)
         fpc.showForTest()
 
         XCTAssertEqual(fpc.state, .half)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, false)
+        XCTAssertEqual(contentVC1.tableView.bounces, false)
 
         fpc.move(to: .full, animated: false)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, true)
+        XCTAssertEqual(contentVC1.tableView.bounces, true)
 
         fpc.move(to: .tip, animated: false)
         XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, false)
+        XCTAssertEqual(contentVC1.tableView.bounces, false)
 
         let exp1 = expectation(description: "move to full with animation")
         fpc.move(to: .full, animated: true) {
             XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, true)
+            XCTAssertEqual(contentVC1.tableView.bounces, true)
             exp1.fulfill()
         }
         wait(for: [exp1], timeout: 1.0)
@@ -35,6 +40,7 @@ class CoreTests: XCTestCase {
         let exp2 = expectation(description: "move to tip with animation")
         fpc.move(to: .tip, animated: false) {
             XCTAssertEqual(contentVC1.tableView.showsVerticalScrollIndicator, false)
+            XCTAssertEqual(contentVC1.tableView.bounces, false)
             exp2.fulfill()
         }
         wait(for: [exp2], timeout: 1.0)
@@ -42,11 +48,13 @@ class CoreTests: XCTestCase {
         // Reset the content vc
         let contentVC2 = UITableViewController(nibName: nil, bundle: nil)
         XCTAssertEqual(contentVC2.tableView.showsVerticalScrollIndicator, true)
+        XCTAssertEqual(contentVC2.tableView.bounces, true)
         fpc.set(contentViewController: contentVC2)
         fpc.track(scrollView: contentVC2.tableView)
         fpc.show(animated: false, completion: nil)
         XCTAssertEqual(fpc.state, .half)
         XCTAssertEqual(contentVC2.tableView.showsVerticalScrollIndicator, false)
+        XCTAssertEqual(contentVC2.tableView.bounces, false)
     }
 
     func test_getBackdropAlpha_1positions() {


### PR DESCRIPTION
Commit 448fc5c has a critical regression in scroll tracking that can cause the scroll content to bounce after moving a panel, for example, pulling down it from full to half state. 

By re-investigating #524, I found that this problem only occurred with the fitToBounds content mode(and a small scroll view content).

Therefore I fixed it in the more specific way.