### PR TITLE
Fix for contentOffset

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -1090,7 +1090,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         // Must use setContentOffset(_:animated) to force-stop deceleration
         guard let scrollView = scrollView else { return }
         var offset = scrollView.contentOffset
-        if contentOffset.y >= 0 {
+        if contentOffset.y != 0 {
             setValue(contentOffset, to: &offset)
         } else {
             offset = CGPoint(x: 0, y: 0)


### PR DESCRIPTION
Found a problem when I use FloatingPanel with UINavigationController which holds some controller with scrollView.
When FloatingPanel goes from state to state scrollView's contentOffset becomes (0, 0) instead of (0, -44) (which is normal if there is a UINavigationBar).
Tried to fix it here.

Also here are two examples before and after fix.
before: https://github.com/scenee/FloatingPanel/assets/340680/eb6cb644-4bbe-4174-ac3e-25885600bffd
after: https://github.com/scenee/FloatingPanel/assets/340680/da4a8e40-6923-45c4-b92e-eb151454f5f2

