### PR TITLE
Fix scroll locking behavior

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -68,7 +68,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
     private var scrollBounce = false
     private var scrollIndictorVisible = false
     private var scrollBounceThreshold: CGFloat = -30.0
-	private var scrollLocked = false
+    private var scrollLocked = false
 
     // MARK: - Interface
 
@@ -1051,12 +1051,12 @@ class Core: NSObject, UIGestureRecognizerDelegate {
 
     private func lockScrollView(strict: Bool = false) {
         guard let scrollView = scrollView else { return }
-		if scrollLocked {
-			os_log(msg, log: devLog, type: .debug, "Already scroll locked")
-			return
-		}
 
-		scrollBounce = scrollView.bounces
+        if scrollLocked {
+            os_log(msg, log: devLog, type: .debug, "Already scroll locked")
+            return
+        }
+        scrollBounce = scrollView.bounces
         if !strict, shouldLooselyLockScrollView {
             // Don't change its `bounces` property. If it's changed, it will cause its scroll content offset jump at
             // the most expanded anchor position while seamlessly scrolling content. This problem only occurs where its
@@ -1068,9 +1068,9 @@ class Core: NSObject, UIGestureRecognizerDelegate {
         }
         os_log(msg, log: devLog, type: .debug, "lock scroll view")
 
-		scrollLocked = true
-		scrollView.isDirectionalLockEnabled = true
 
+        scrollLocked = true
+        scrollView.isDirectionalLockEnabled = true
         switch layoutAdapter.position {
         case .top, .bottom:
             scrollIndictorVisible = scrollView.showsVerticalScrollIndicator
@@ -1083,13 +1083,13 @@ class Core: NSObject, UIGestureRecognizerDelegate {
 
     private func unlockScrollView() {
         guard let scrollView = scrollView else { return }
-		if !scrollLocked {
-			os_log(msg, log: devLog, type: .debug, "Already scroll unlocked.")
-			return
-		}
+        if !scrollLocked {
+            os_log(msg, log: devLog, type: .debug, "Already scroll unlocked.")
+            return
+        }
         os_log(msg, log: devLog, type: .debug, "unlock scroll view")
 
-		scrollLocked = false
+        scrollLocked = false
         scrollView.bounces = scrollBounce
         scrollView.isDirectionalLockEnabled = false
         switch layoutAdapter.position {

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -24,6 +24,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
                     scrollBounce = cur.bounces
                     scrollIndictorVisible = cur.showsVerticalScrollIndicator
                 }
+                scrollLocked = false
             } else {
                 if let pre = oldValue {
                     pre.isDirectionalLockEnabled = false

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -109,12 +109,6 @@ extension UIGestureRecognizer.State: CustomDebugStringConvertible {
 #endif
 
 extension UIScrollView {
-    var isLocked: Bool {
-        return !showsVerticalScrollIndicator && !bounces && isDirectionalLockEnabled
-    }
-    var isLooselyLocked: Bool {
-        return !showsVerticalScrollIndicator && isDirectionalLockEnabled
-    }
     var fp_contentOffsetMax: CGPoint {
         return CGPoint(x: max((contentSize.width + adjustedContentInset.right) - bounds.width, 0.0),
                        y: max((contentSize.height + adjustedContentInset.bottom) - bounds.height, 0.0))


### PR DESCRIPTION
Use a separate `scrollLocked` var instead of abusing the scrollView's properties to store the locked state.
Fixes an issue where the scroll indicators were no longer visible because `lockScrollView()` was executed twice before `unlockScrollView()` was called (due to the user changing `showsVerticalScrollIndicator` mid-animation).