### PR TITLE
Removing fatal error in method transitionDuration

### DIFF
--- a/Sources/Transitioning.swift
+++ b/Sources/Transitioning.swift
@@ -84,7 +84,7 @@ class ModalPresentTransition: NSObject, UIViewControllerAnimatedTransitioning {
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         guard
             let fpc = transitionContext?.viewController(forKey: .to) as? FloatingPanelController
-        else { fatalError()}
+        else { return 0.0 }
 
         let animator = fpc.animatorForPresenting(to: fpc.layout.initialState)
         return TimeInterval(animator.duration)
@@ -119,7 +119,7 @@ class ModalDismissTransition: NSObject, UIViewControllerAnimatedTransitioning {
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         guard
             let fpc = transitionContext?.viewController(forKey: .from) as? FloatingPanelController
-        else { fatalError()}
+        else { return 0.0 }
 
         let animator = fpc.animatorForDismissing(with: .zero)
         return TimeInterval(animator.duration)


### PR DESCRIPTION
### Summary
This PR modifies the `transitionDuration(using:)` method in `FloatingPanelController` to return `0.0` instead of calling `fatalError` when the `FloatingPanelController` instance is not found. This change is crucial for several reasons:

1. **Avoiding Crashes in Production**: Using `fatalError` in production can lead to unexpected crashes, which are detrimental to user experience. It's safer to return a default value like `0.0` and handle the scenario gracefully.

2. **Improved Stability**: By returning `0.0`, the application can continue running, allowing for better stability and user satisfaction. This approach also aligns with the principle of fail-safety, where the system continues operating under error conditions.

3. **Real-World Case**: In our large-scale project, we encountered a crash at this specific point due to the `fatalError`. Given the size and complexity of our application, it has been challenging to pinpoint the exact cause. Switching to a return value of `0.0` would significantly help us mitigate the issue and maintain app stability while we investigate further.

4. **Maintainability**: Returning a default value makes the codebase more maintainable and easier to debug, as it avoids abrupt termination and allows for logging or other error handling mechanisms.

### Code Changes
```swift
func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
    guard
        let fpc = transitionContext?.viewController(forKey: .to) as? FloatingPanelController
    else { return 0.0 }
    // Existing logic
}
```

We believe this change will benefit not only our project but also others who might face similar issues. Your consideration and review are greatly appreciated.