### PR TITLE
Let delegate decide whether the scroll view should be locked during state transitions

### DIFF
--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -125,6 +125,10 @@ import os.log
         shouldAllowToScroll scrollView: UIScrollView,
         in state: FloatingPanelState
     ) -> Bool
+    
+    /// Determines whether the scroll content should be locked during transition to the specified state. If not implemented, the content will always be locked.
+    @objc(floatingPanel:shouldLockScrollView:transitioningToState:)
+    optional func floatingPanel(_ fpc: FloatingPanelController, shouldLockScrollView scrollView: UIScrollView, transitioningToState state: FloatingPanelState) -> Bool
 }
 
 ///

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -933,8 +933,8 @@ class Core: NSObject, UIGestureRecognizerDelegate {
                 let translation = data.value - initialData.value
                 self.backdropView.alpha = self.getBackdropAlpha(at: current, with: translation)
 
-                // Pin the offset of the tracking scroll view while moving by this animator
-                if let scrollView = self.scrollView {
+                // Pin the offset of the tracking scroll view while moving by this animator, unless the delegate decides otherwise
+                if let scrollView = self.scrollView, ownerVC.delegate?.floatingPanel?(ownerVC, shouldLockScrollView: scrollView, transitioningToState: state) ?? true {
                     self.stopScrolling(at: self.initialScrollOffset)
                     os_log(msg, log: devLog, type: .debug, "move -- pinning scroll offset = \(scrollView.contentOffset)")
                 }


### PR DESCRIPTION
In #587 the behavior of the panel was changed so that the content of the tracked scroll view is always locked during state transitions. In some cases it's useful to be able to adjust the scroll offset during these transitions, so a delegate method has been introduced, letting the user of the library decide on this behavior.