### PR TITLE
Disallow interrupting the panel interaction while bouncing over the most expansion state

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -561,7 +561,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
     }
 
     private func interruptAnimationIfNeeded() {
-        if let animator = self.moveAnimator, animator.isRunning {
+        if let animator = self.moveAnimator, animator.isRunning, 0 <= layoutAdapter.offsetFromMostExpandedAnchor {
             os_log(msg, log: devLog, type: .debug, "the attraction animator interrupted!!!")
             animator.stopAnimation(true)
             endAttraction(false)


### PR DESCRIPTION
This will resolve #633's 2nd issue.