### PR TITLE
fix: Fix offset reset issue caused by floating-point precision at boundary positions

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -432,7 +432,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
             let velocity = value(of: panGesture.velocity(in: panGesture.view))
             let location = panGesture.location(in: surfaceView)
 
-            let insideMostExpandedAnchor = 0 < layoutAdapter.offsetFromMostExpandedAnchor
+            let insideMostExpandedAnchor = 0 < floor(layoutAdapter.offsetFromMostExpandedAnchor)
 
             os_log(msg, log: devLog, type: .debug, """
                 scroll gesture(\(state):\(panGesture.state)) -- \
@@ -927,7 +927,7 @@ class Core: NSObject, UIGestureRecognizerDelegate {
     }
 
     private func shouldAttract(to state: FloatingPanelState) -> Bool {
-        if layoutAdapter.position(for: state) == value(of: layoutAdapter.surfaceLocation) {
+        if floor(layoutAdapter.position(for: state)) == floor(value(of: layoutAdapter.surfaceLocation)) {
             return false
         }
         return true


### PR DESCRIPTION

When the panel is already at a boundary position, floating-point precision errors on some devices can cause unexpected offset resets in the position calculation.

By applying floor() to the position calculations for top, left, bottom, and right edges in FloatingPanelLayoutAnchor, we ensure integer values are returned, preventing layout issues caused by floating-point precision errors.

https://github.com/scenee/FloatingPanel/issues/626

[FloatingPanelSample.zip](https://github.com/user-attachments/files/24577708/FloatingPanelSample.zip)

https://github.com/user-attachments/assets/91def1cb-33a5-4b52-baee-c001fa44f767

