### PR TITLE
Fix: Perform view updates during scroll tracking

### DIFF
--- a/Sources/SwiftUI/View+floatingPanelScrollTracking.swift
+++ b/Sources/SwiftUI/View+floatingPanelScrollTracking.swift
@@ -68,7 +68,11 @@ private struct ScrollViewRepresentable<Content>: UIViewControllerRepresentable w
         return vc
     }
 
-    func updateUIViewController(_ uiViewController: ScrollViewHostingController<Content>, context: Context) {
+    func updateUIViewController(
+        _ uiViewController: ScrollViewHostingController<Content>,
+        context: Context
+    ) {
+        uiViewController.rootView = content()
     }
 
     class ScrollViewHostingController<V>: UIHostingController<V> where V: View {


### PR DESCRIPTION
Thank you for providing this great package, @scenee. We have been using it in our app for years now, since it is the best solution for panels below the tab bar.
We used to use the SwiftUI implementation from some issue thread, IIRC, but are currently switching to version 3.2.0 with official SwiftUI support. Thereby noticing this issue reappear:

When we enable `floatingPanelScrollTracking` on our view inside of the floating panel, some view updates are performed (i.e., SwiftUI views are being instantiated) but no rendering (i.e., `body` evaluations) occurs.

Example code:

```swift
content
    .floatingPanel(
        coordinator: ContentPanelCoordinator.self,
        onEvent: onEvent
    ) { proxy in
        panelContent
            .floatingPanelScrollTracking(proxy: proxy) // scroll tracking breaks view updates
    }
```

We tracked this down to the scroll tracking, and it seems that the performing of view updates inside of the `ScrollViewRepresentable` was missing.

This seems similar to #675.