### PR TITLE
Fix panel interactivity broken by floatingPanelState(_:) with delegate callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         include:
           - swift: "5"
+            xcode: "26.2"
+            runs-on: macos-15
+          - swift: "5"
             xcode: "16.4"
             runs-on: macos-15
           - swift: "5.10"
@@ -37,8 +40,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: "26.0.1"
-            xcode: "26.0.1"
+          - os: "26.2"
+            xcode: "26.2"
             sim: "iPhone 16 Pro"
             parallel: NO # Stop random test job failures
             runs-on: macos-15
@@ -66,7 +69,7 @@ jobs:
   example:
     runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.0.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
     strategy:
       fail-fast: false
       matrix:
@@ -93,21 +96,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["26.0.1", "16.4", "15.4"]
+        xcode: ["26.2", "16.4", "15.4"]
         platform: [iphoneos, iphonesimulator]
         arch: [x86_64, arm64]
         exclude:
           - platform: iphoneos
             arch: x86_64
         include:
-          # 26.0.1
+          # 26.x
           - platform: iphoneos
-            xcode: "26.0.1"
-            sys: "ios26.0"
+            xcode: "26.2"
+            sys: "ios26.2"
             runs-on: macos-15
           - platform: iphonesimulator
-            xcode: "26.0.1"
-            sys: "ios26.0-simulator"
+            xcode: "26.2"
+            sys: "ios26.2-simulator"
             runs-on: macos-15
           # 18.5
           - platform: iphoneos
@@ -138,7 +141,7 @@ jobs:
   cocoapods:
     runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.0.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v4
       - name: "CocoaPods: pod lib lint"

--- a/FloatingPanel.xcodeproj/project.pbxproj
+++ b/FloatingPanel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5404FC6D2F3D900E00BCC99B /* CoordinatorProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5404FC6B2F3D900E00BCC99B /* CoordinatorProxyTests.swift */; };
 		542753C622C49A6E00D17955 /* LayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542753C522C49A6E00D17955 /* LayoutTests.swift */; };
 		5431025B2DB8AAB800A927EF /* View+floatingPanelSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543102592DB8AAB800A927EF /* View+floatingPanelSurface.swift */; };
 		5431025E2DB8AAB800A927EF /* View+floatingPanelConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543102572DB8AAB800A927EF /* View+floatingPanelConfiguration.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5404FC6B2F3D900E00BCC99B /* CoordinatorProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorProxyTests.swift; sourceTree = "<group>"; };
 		542753C522C49A6E00D17955 /* LayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutTests.swift; sourceTree = "<group>"; };
 		542753C722C49A8F00D17955 /* TestSupports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSupports.swift; sourceTree = "<group>"; };
 		543102572DB8AAB800A927EF /* View+floatingPanelConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+floatingPanelConfiguration.swift"; sourceTree = "<group>"; };
@@ -121,6 +123,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5404FC6C2F3D900E00BCC99B /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				5404FC6B2F3D900E00BCC99B /* CoordinatorProxyTests.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
 		545DB9B72151169500CA77B8 = {
 			isa = PBXGroup;
 			children = (
@@ -169,6 +179,7 @@
 		545DB9CE2151169500CA77B8 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				5404FC6C2F3D900E00BCC99B /* SwiftUI */,
 				54A6B6B022968B530077F348 /* CoreTests.swift */,
 				545DB9CF2151169500CA77B8 /* ControllerTests.swift */,
 				547F7A9B2A6E946000303905 /* GestureTests.swift */,
@@ -363,6 +374,7 @@
 				542753C622C49A6E00D17955 /* LayoutTests.swift in Sources */,
 				54A6B6B82296A8520077F348 /* SurfaceViewTests.swift in Sources */,
 				546055BF2333C4740069F400 /* TestSupports.swift in Sources */,
+				5404FC6D2F3D900E00BCC99B /* CoordinatorProxyTests.swift in Sources */,
 				547F7A9C2A6E946000303905 /* GestureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/SwiftUI/FloatingPanelView.swift
+++ b/Sources/SwiftUI/FloatingPanelView.swift
@@ -249,7 +249,10 @@ extension FloatingPanelCoordinatorProxy {
 
     // Update the state of FloatingPanelController
     func update(state: FloatingPanelState?) {
-        guard let state = state else { return }
+        guard
+            let state = state,
+            controller.state != state
+        else { return }
         controller.move(to: state, animated: false)
     }
 

--- a/Sources/SwiftUI/FloatingPanelView.swift
+++ b/Sources/SwiftUI/FloatingPanelView.swift
@@ -161,6 +161,9 @@ extension FloatingPanelView {
 class FloatingPanelCoordinatorProxy {
     private let origin: any FloatingPanelCoordinator
     private var stateBinding: Binding<FloatingPanelState?>
+    /// Tracks the last binding value seen by `update(state:)` to detect actual changes
+    /// vs. stale values from unrelated SwiftUI re-renders.
+    private var lastKnownBindingState: FloatingPanelState?
 
     private var subscriptions: Set<AnyCancellable> = Set()
 
@@ -249,8 +252,10 @@ extension FloatingPanelCoordinatorProxy {
 
     // Update the state of FloatingPanelController
     func update(state: FloatingPanelState?) {
+        defer { lastKnownBindingState = state }
         guard
             let state = state,
+            state != lastKnownBindingState,
             controller.state != state
         else { return }
         controller.move(to: state, animated: false)

--- a/Tests/SwiftUI/CoordinatorProxyTests.swift
+++ b/Tests/SwiftUI/CoordinatorProxyTests.swift
@@ -1,0 +1,141 @@
+// Copyright 2018 the FloatingPanel authors. All rights reserved. MIT license.
+
+import SwiftUI
+import XCTest
+
+@testable import FloatingPanel
+
+@available(iOS 14, *)
+class CoordinatorProxyTests: XCTestCase {
+    override func setUp() {}
+    override func tearDown() {}
+
+    // MARK: - Test doubles
+
+    /// Records calls to `move(to:animated:completion:)` without performing real movement.
+    final class SpyFloatingPanelController: FloatingPanelController {
+        struct MoveCall {
+            let state: FloatingPanelState
+            let animated: Bool
+        }
+        fileprivate(set) var moveCalls: [MoveCall] = []
+
+        override func move(
+            to state: FloatingPanelState,
+            animated: Bool,
+            completion: (() -> Void)? = nil
+        ) {
+            moveCalls.append(MoveCall(state: state, animated: animated))
+            super.move(to: state, animated: animated, completion: completion)
+        }
+    }
+
+    /// A minimal `FloatingPanelCoordinator` that allows injecting a custom controller.
+    final class TestCoordinator: FloatingPanelCoordinator {
+        typealias Event = Void
+        let proxy: FloatingPanelProxy
+        let action: (Event) -> Void
+
+        init(action: @escaping (Event) -> Void) {
+            self.action = action
+            self.proxy = FloatingPanelProxy(controller: FloatingPanelController())
+        }
+
+        /// Designated initializer for tests — accepts a pre-made controller.
+        init(controller: FloatingPanelController) {
+            self.action = { _ in }
+            self.proxy = FloatingPanelProxy(controller: controller)
+        }
+
+        func setupFloatingPanel<Main: View, Content: View>(
+            mainHostingController: UIHostingController<Main>,
+            contentHostingController: UIHostingController<Content>
+        ) {
+            contentHostingController.view.backgroundColor = .clear
+            controller.set(contentViewController: contentHostingController)
+            controller.addPanel(toParent: mainHostingController, animated: false)
+        }
+
+        func onUpdate<Representable>(
+            context: UIViewControllerRepresentableContext<Representable>
+        ) where Representable: UIViewControllerRepresentable {}
+    }
+
+    // MARK: - Helpers
+
+    private func makeProxy(
+        spy: SpyFloatingPanelController
+    ) -> FloatingPanelCoordinatorProxy {
+        let coordinator = TestCoordinator(controller: spy)
+        spy.showForTest()
+        var state: FloatingPanelState? = spy.state
+        let binding = Binding<FloatingPanelState?>(
+            get: { state },
+            set: { state = $0 }
+        )
+        return FloatingPanelCoordinatorProxy(
+            coordinator: coordinator,
+            state: binding
+        )
+    }
+}
+
+// MARK: - Issue #680: update(state:) should skip move when state is unchanged
+
+/// Tests for `FloatingPanelCoordinatorProxy.update(state:)` — the internal bridge between
+/// SwiftUI state bindings and `FloatingPanelController`.
+@available(iOS 14, *)
+extension CoordinatorProxyTests {
+    /// During a drag gesture, a delegate callback can trigger a SwiftUI re-render which
+    /// calls `update(state:)` with the current state. The fix ensures this redundant call
+    /// does NOT invoke `controller.move(to:animated:)`, preserving the interactive transition.
+    func test_updateState_skipsMove_whenStateIsUnchanged() {
+        let spy = SpyFloatingPanelController()
+        let proxy = makeProxy(spy: spy)
+        XCTAssertEqual(spy.state, .half)
+
+        // Clear any move calls from setup
+        spy.moveCalls.removeAll()
+
+        // update(state:) with the SAME state must not trigger move(to:)
+        proxy.update(state: .half)
+
+        XCTAssertTrue(
+            spy.moveCalls.isEmpty,
+            "move(to:animated:) must not be called when the state is unchanged, "
+                + "but was called \(spy.moveCalls.count) time(s)"
+        )
+    }
+
+    func test_updateState_movesPanel_whenStateIsDifferent() {
+        let spy = SpyFloatingPanelController()
+        let proxy = makeProxy(spy: spy)
+        XCTAssertEqual(spy.state, .half)
+
+        spy.moveCalls.removeAll()
+
+        proxy.update(state: .full)
+
+        XCTAssertEqual(
+            spy.moveCalls.count, 1,
+            "move(to:animated:) should be called exactly once"
+        )
+        XCTAssertEqual(spy.moveCalls.first?.state, .full)
+        XCTAssertEqual(spy.moveCalls.first?.animated, false)
+    }
+
+    func test_updateState_doesNothing_whenStateIsNil() {
+        let spy = SpyFloatingPanelController()
+        let proxy = makeProxy(spy: spy)
+        XCTAssertEqual(spy.state, .half)
+
+        spy.moveCalls.removeAll()
+
+        proxy.update(state: nil)
+
+        XCTAssertTrue(
+            spy.moveCalls.isEmpty,
+            "move(to:animated:) must not be called when state is nil"
+        )
+    }
+}


### PR DESCRIPTION
## Fixed

- `floatingPanelState(_:)` breaking panel interactivity when used with `FloatingPanelControllerDelegate` methods that trigger SwiftUI re-renders (e.g. opacity changes). Delegate callbacks caused redundant `move(to:animated:)` calls during drag gestures, interrupting the interactive transition.

## Added 

- `lastKnownBindingState` tracking in `CoordinatorProxy.update(state:)` to skip moves when the binding value hasn't actually changed, preventing stale state from reverting the panel position.
- `CoordinatorProxyTests` and reorganize existing tests into a `UIKit` subfolder.


## Improvement

- Updated CI environment with Xcode 26.2

Closes #680
