### PR TITLE
Complete the transition instead of trapping in interruptibleAnimator

### DIFF
--- a/Sources/Transitioning.swift
+++ b/Sources/Transitioning.swift
@@ -2,6 +2,22 @@
 
 import UIKit
 
+/// An animator that immediately completes `transitionContext`.
+///
+/// UIKit can run a panel transition with a context whose participating view controller isn't the
+/// panel — for instance when a stack of presented controllers is dismissed in one step. Finishing
+/// the transition leaves the presentation state consistent, where trapping would kill the app.
+private func makeCompletingAnimator(
+    for transitionContext: UIViewControllerContextTransitioning
+) -> UIViewImplicitlyAnimating {
+    let animator = UIViewPropertyAnimator(duration: 0, curve: .linear)
+    animator.addAnimations {}
+    animator.addCompletion { _ in
+        transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+    }
+    return animator
+}
+
 class ModalTransition: NSObject, UIViewControllerTransitioningDelegate {
     func animationController(forPresented presented: UIViewController,
                              presenting: UIViewController,
@@ -93,7 +109,7 @@ class ModalPresentTransition: NSObject, UIViewControllerAnimatedTransitioning {
     func interruptibleAnimator(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
         guard
             let fpc = transitionContext.viewController(forKey: .to) as? FloatingPanelController
-        else { fatalError() }
+        else { return makeCompletingAnimator(for: transitionContext) }
 
         if let animator = fpc.transitionAnimator {
             return animator
@@ -104,10 +120,9 @@ class ModalPresentTransition: NSObject, UIViewControllerAnimatedTransitioning {
             fpc?.suspendTransitionAnimator(false)
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }
-        guard let transitionAnimator = fpc.transitionAnimator else {
-            fatalError("The panel state must be `hidden` but it is `\(fpc.state)`")
-        }
-        return transitionAnimator
+        // `show(animated:)` above already scheduled `completeTransition`, so this fallback must not
+        // complete the context a second time.
+        return fpc.transitionAnimator ?? UIViewPropertyAnimator(duration: 0, curve: .linear)
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
@@ -128,7 +143,7 @@ class ModalDismissTransition: NSObject, UIViewControllerAnimatedTransitioning {
     func interruptibleAnimator(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
         guard
             let fpc = transitionContext.viewController(forKey: .from) as? FloatingPanelController
-        else { fatalError() }
+        else { return makeCompletingAnimator(for: transitionContext) }
 
         if let animator = fpc.transitionAnimator {
             return animator
@@ -139,7 +154,9 @@ class ModalDismissTransition: NSObject, UIViewControllerAnimatedTransitioning {
             fpc?.suspendTransitionAnimator(false)
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }
-        return fpc.transitionAnimator!
+        // `hide(animated:)` above already scheduled `completeTransition`, so this fallback must not
+        // complete the context a second time.
+        return fpc.transitionAnimator ?? UIViewPropertyAnimator(duration: 0, curve: .linear)
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {

--- a/Tests/ControllerTests.swift
+++ b/Tests/ControllerTests.swift
@@ -367,6 +367,31 @@ class ControllerTests: XCTestCase {
 
         XCTAssertEqual(fpc.state, .half)
     }
+
+    func test_modalDismissTransition_withoutPanelInContext() {
+        // UIKit can run the transition with a context whose from-view controller isn't the panel,
+        // for instance when a stack of presented view controllers is dismissed in one step.
+        let context = MockTransitionContext(viewControllers: [.from: UIViewController()])
+
+        ModalDismissTransition().animateTransition(using: context)
+        waitRunLoop(secs: 0.1)
+
+        XCTAssertEqual(context.completedTransition, true)
+    }
+
+    func test_modalPresentTransition_withoutPanelInContext() {
+        let context = MockTransitionContext(viewControllers: [.to: UIViewController()])
+
+        ModalPresentTransition().animateTransition(using: context)
+        waitRunLoop(secs: 0.1)
+
+        XCTAssertEqual(context.completedTransition, true)
+    }
+
+    func test_modalDismissTransition_zeroDurationWhenPanelIsMissing() {
+        let context = MockTransitionContext(viewControllers: [.from: UIViewController()])
+        XCTAssertEqual(ModalDismissTransition().transitionDuration(using: context), 0.0)
+    }
 }
 
 private class MyZombieViewController: UIViewController, FloatingPanelLayout, FloatingPanelBehavior, FloatingPanelControllerDelegate {

--- a/Tests/TestSupports.swift
+++ b/Tests/TestSupports.swift
@@ -109,3 +109,33 @@ class MockTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator
     var targetTransform: CGAffineTransform = .identity
 }
 
+class MockTransitionContext: NSObject, UIViewControllerContextTransitioning {
+    private let viewControllers: [UITransitionContextViewControllerKey: UIViewController]
+    private(set) var completedTransition: Bool?
+
+    init(viewControllers: [UITransitionContextViewControllerKey: UIViewController]) {
+        self.viewControllers = viewControllers
+    }
+
+    func viewController(forKey key: UITransitionContextViewControllerKey) -> UIViewController? {
+        return viewControllers[key]
+    }
+    func completeTransition(_ didComplete: Bool) {
+        completedTransition = didComplete
+    }
+
+    let containerView = UIView()
+    var isAnimated: Bool = true
+    var isInteractive: Bool = false
+    var transitionWasCancelled: Bool = false
+    var presentationStyle: UIModalPresentationStyle = .custom
+    var targetTransform: CGAffineTransform = .identity
+    func updateInteractiveTransition(_ percentComplete: CGFloat) {}
+    func finishInteractiveTransition() {}
+    func cancelInteractiveTransition() {}
+    func pauseInteractiveTransition() {}
+    func view(forKey key: UITransitionContextViewKey) -> UIView? { nil }
+    func initialFrame(for vc: UIViewController) -> CGRect { .zero }
+    func finalFrame(for vc: UIViewController) -> CGRect { .zero }
+}
+


### PR DESCRIPTION
Thanks for #642 — this is a follow-up to it.

#641 was titled for `interruptibleAnimator`, but the code quoted in the report was `transitionDuration`, so #642 fixed the methods that were quoted. Both `interruptibleAnimator` methods still have the bare `fatalError()`, and they trap on the same condition:

```swift
guard let fpc = transitionContext.viewController(forKey: .from) as? FloatingPanelController
else { fatalError() }   // Transitioning.swift:131
```

### When it fires

A panel is presented modally on a view controller that is itself presented modally. Dismissing the outermost presentation tears the whole stack down in one step, and UIKit then runs the panel's dismiss transition with the *intermediate* view controller as `.from`. The cast fails and the app is killed.

### Impact

This is currently the single highest-volume crash in a shipping iOS app. It's a latent condition that started firing at scale without any app-side change — the same unmodified binary that had been stable for weeks began crashing, which points at an OS behaviour change rather than anything in the app. It's overwhelmingly iOS 26.5.x, but a small share of occurrences are on iOS 18.x, so it isn't iOS 26-specific.

```
_assertionFailure
specialized ModalDismissTransition.interruptibleAnimator(using:) (Transitioning.swift:131)
@objc ModalPresentTransition.animateTransition(using:)          <- linker-folded thunk; the dismiss path
___UIViewControllerTransitioningRunCustomTransitionWithRequest_block_invoke_3
+[UIKeyboardSceneDelegate _pinInputViewsForKeyboardSceneDelegate:onBehalfOfResponder:duringBlock:]
___UIViewControllerTransitioningRunCustomTransitionWithRequest_block_invoke_2
+[UIView(Animation) _setAlongsideAnimations:toRunByEndOfBlock:animated:]
_UIViewControllerTransitioningRunCustomTransitionWithRequest
__77-[UIPresentationController runTransitionForCurrentStateAnimated:handoffData:]_block_invoke_3
```

The keyboard-pinning frame appears in every sample, so a keyboard transition is consistently in flight at the same time.

### The change

Both guards now return an animator that immediately completes the transition. The two `nil`-`transitionAnimator` fallbacks below them deliberately return a *non*-completing animator instead, because `show()`/`hide()` directly above have already scheduled `completeTransition` and completing twice would be worse than the trap. This also removes a force-unwrap of `fpc.transitionAnimator` on the dismiss path.

Worst case after this is a panel that disappears without animating, rather than a terminated process.

### Tests

Added to `ControllerTests`, covering both guard paths, plus one pinning the existing zero-duration `transitionDuration` behaviour on the same condition. `MockTransitionContext` follows the existing `MockTransitionCoordinator` in `TestSupports`. The dismiss test also verifies `completeTransition` is genuinely called, since a fallback that silently never completes would be worse than the crash.

Left alone deliberately: the `fatalError()` in `PresentationController.addFloatingPanel()`, where `presentedViewController` is the panel by construction — happy to fold it in if you'd prefer.